### PR TITLE
Fix bugs for some hdf5 files

### DIFF
--- a/jupyterlab_hdf/baseHandler.py
+++ b/jupyterlab_hdf/baseHandler.py
@@ -6,6 +6,7 @@
 import h5py
 import json
 import os
+import traceback
 from tornado import gen
 from tornado.httpclient import HTTPError
 
@@ -57,14 +58,14 @@ class HdfBaseManager:
                 with h5py.File(fpath, 'r') as f: pass
             except Exception as e:
                 msg = (f'The request did not specify a file that `h5py` could understand.\n'
-                       f'Error: {e}')
+                       f'Error: {traceback.format_exc()}')
                 _handleErr(401, msg)
             try:
                 with h5py.File(fpath, 'r') as f:
                     out = self._get(f, uri, row, col)
             except Exception as e:
                 msg = (f'Found and opened file, error getting contents from object specified by the uri.\n'
-                       f'Error: {e}')
+                       f'Error: {traceback.format_exc()}')
                 _handleErr(500, msg)
 
             return out

--- a/jupyterlab_hdf/util.py
+++ b/jupyterlab_hdf/util.py
@@ -4,6 +4,8 @@
 # Distributed under the terms of the Modified BSD License.
 
 import re
+import numpy as np
+
 
 __all__ = ['chunkSlice', 'dsetChunk', 'dsetContentDict', 'dsetDict', 'groupDict', 'uriJoin', 'uriName']
 
@@ -18,11 +20,23 @@ def dsetChunk(dset, row, col):
     return dset[slice(*row), slice(*col)].tolist()
 
 
+def serialize_value(v):
+    """
+    Turns a value into a JSON serializable version
+    """
+    if isinstance(v, list):
+        return [serialize_value(i) for i in v]
+    if isinstance(v, np.ndarray):
+        return serialize_value(v.tolist())
+    if isinstance(v, bytes):
+        return v.decode()
+    return v
+
 ## create dicts to be converted to json
 def dsetContentDict(dset, row=None, col=None):
     return dict([
         # metadata
-        ('attrs', dict(*dset.attrs.items())),
+        ('attrs', {k: serialize_value(v) for k, v in dset.attrs.items()}),
         ('dtype', dset.dtype.str),
         ('ndim', dset.ndim),
         ('shape', dset.shape),


### PR DESCRIPTION
As I was preparing a demo, I noticed this wasn't working for some hdf5 which which have attributes that are numpy arrays. See https://github.com/RobertRosca/hdf5-examples/blob/9c20601b27af367974214a5cc468592068e93122/1-openPMD-example.ipynb

I fixed this by turning numpy arrays into lists and bytes into strings. Then they are JSON serializiable.  I also added full traceback to some of the errors, which were helpful for debugging this.