### PR TITLE
Tweaks to use jupyterlab-hdf as standalone web app

### DIFF
--- a/jupyterlab_hdf/__init__.py
+++ b/jupyterlab_hdf/__init__.py
@@ -13,32 +13,27 @@ from .snippet import HdfSnippetHandler
 
 path_regex = r'(?P<path>(?:(?:/[^/]+)+|/?))'
 
-def _jupyter_server_extension_paths():
-    return [{
-        'module': 'jupyterlab_hdf'
-    }]
 
-def _load_handlers(nb_server_app, web_app):
+def _jupyter_server_extension_paths():
+    return [{'module': 'jupyterlab_hdf'}]
+
+
+def _load_handlers(notebook_dir, web_app):
     # Prepend the base_url so that it works in a jupyterhub setting
-    base_url = web_app.settings['base_url']
+    base_url = web_app.settings['base_url'] if 'base_url' in web_app.settings else '/'
 
     contents = url_path_join(base_url, 'hdf/contents')
     data = url_path_join(base_url, 'hdf/data')
     snippet = url_path_join(base_url, 'hdf/snippet')
 
     handlers = [
-        (contents + '/(.*)',
-         HdfContentsHandler,
-         {"notebook_dir": nb_server_app.notebook_dir}),
-        (data + '/(.*)',
-         HdfDataHandler,
-         {"notebook_dir": nb_server_app.notebook_dir}),
-        (snippet + '/(.*)',
-         HdfSnippetHandler,
-         {"notebook_dir": nb_server_app.notebook_dir}),
+        (contents + '/(.*)', HdfContentsHandler, {'notebook_dir': notebook_dir}),
+        (data + '/(.*)', HdfDataHandler, {'notebook_dir': notebook_dir}),
+        (snippet + '/(.*)', HdfSnippetHandler, {'notebook_dir': notebook_dir}),
     ]
 
     web_app.add_handlers('.*$', handlers)
+
 
 def load_jupyter_server_extension(nb_server_app):
     """
@@ -47,5 +42,4 @@ def load_jupyter_server_extension(nb_server_app):
     Args:
         nb_server_app (NotebookApp): handle to the Notebook webserver instance.
     """
-    web_app = nb_server_app.web_app
-    _load_handlers(nb_server_app, web_app)
+    _load_handlers(nb_server_app.notebook_dir, nb_server_app.web_app)


### PR DESCRIPTION
A small change to the `_load_handlers` signature to make it less dependent on the NotebookApp format.

This allows to to serve the handler with a standalone Tornado App instead of a JupyterLab instance:
```
import os
import tornado
from jupyterlab_hdf import _load_handlers


if __name__ == "__main__":
    app = tornado.web.Application()
    _load_handlers(os.path.abspath(os.path.curdir), app)
    app.listen(8888)
    tornado.ioloop.IOLoop.current().start()
```