### PR TITLE
n-dimensional support via parse_index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ MANIFEST
 *.code-workspace
 .history
 .vscode
+
+.autoversion

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.autoversion
 lib/
 node_modules/
 
@@ -18,6 +19,7 @@ MANIFEST
 /scratch/*.cutie
 /scratch/*.h5
 /scratch/*.hdf5
+/scratch/Untitled*
 
 # temp/system files
 *~
@@ -36,4 +38,6 @@ MANIFEST
 .history
 .vscode
 
-.autoversion
+# tmp dev stuff
+json.py
+json.ts

--- a/jupyterlab_hdf/baseHandler.py
+++ b/jupyterlab_hdf/baseHandler.py
@@ -95,7 +95,7 @@ class HdfBaseHandler(APIHandler):
         _vals = (self.get_query_argument(kw, default=None) for kw in _kws)
         kwargs = {kw:(val if val else None) for kw,val in zip(_kws, _vals)}
 
-        self.log.info('kwargs: {}'.format(kwargs))
+        kwargs['log'] = self.log
 
         try:
             self.finish(simplejson.dumps(self.manager.get(path, uri, **kwargs), ignore_nan=True))

--- a/jupyterlab_hdf/baseHandler.py
+++ b/jupyterlab_hdf/baseHandler.py
@@ -4,8 +4,8 @@
 # Distributed under the terms of the Modified BSD License.
 
 import h5py
-import json
 import os
+import simplejson
 import traceback
 from tornado import gen
 from tornado.httpclient import HTTPError
@@ -102,7 +102,7 @@ class HdfBaseHandler(APIHandler):
         col = self.getQueryArguments('col', int)
 
         try:
-            self.finish(json.dumps(self.manager.get(path, uri, row, col)))
+            self.finish(simplejson.dumps(self.manager.get(path, uri, row, col), ignore_nan=True))
 
         except HTTPError as err:
             self.set_status(err.code)

--- a/jupyterlab_hdf/baseHandler.py
+++ b/jupyterlab_hdf/baseHandler.py
@@ -112,7 +112,7 @@ class HdfBaseHandler(APIHandler):
         """
         uri = '/' + self.get_query_argument('uri').lstrip('/')
 
-        _kws = ('ixstr', 'subixstr')
+        _kws = ('atleast_2d', 'ixstr', 'subixstr')
         _vals = (self.get_query_argument(kw, default=None) for kw in _kws)
         kwargs = {kw:(val if val else None) for kw,val in zip(_kws, _vals)}
 

--- a/jupyterlab_hdf/baseHandler.py
+++ b/jupyterlab_hdf/baseHandler.py
@@ -91,8 +91,9 @@ class HdfBaseHandler(APIHandler):
         """
         uri = '/' + self.get_query_argument('uri').lstrip('/')
 
-        kws = ('ixstr', 'subixstr')
-        kwargs = {kw:self.get_query_argument(kw) for kw in kws}
+        _kws = ('ixstr', 'subixstr')
+        _vals = (self.get_query_argument(kw, default=None) for kw in _kws)
+        kwargs = {kw:(val if val else None) for kw,val in zip(_kws, _vals)}
 
         self.log.info('kwargs: {}'.format(kwargs))
 

--- a/jupyterlab_hdf/contents.py
+++ b/jupyterlab_hdf/contents.py
@@ -14,19 +14,21 @@ __all__ = ['HdfContentsManager', 'HdfContentsHandler']
 class HdfContentsManager(HdfFileManager):
     """Implements HDF5 contents handling
     """
-    def _getFromFile(self, f, uri, row, col):
+    def _getFromFile(self, f, uri, ixstr):
         obj = f[uri]
 
         if isinstance(obj, h5py.Group):
             return [(groupDict if isinstance(val, h5py.Group) else dsetDict)
                         (name=name, uri=uriJoin(uri, name))
                     for name,val in obj.items()]
-        else:
+        elif isinstance(obj, h5py.Dataset):
             return dsetDict(
                 name=uriName(uri),
                 uri=uri,
-                content=dsetContentDict(obj, row, col),
+                content=dsetContentDict(obj, ixstr),
             )
+        else:
+            raise ValueError("unknown h5py obj: %s" % obj)
 
 
 ## handler

--- a/jupyterlab_hdf/contents.py
+++ b/jupyterlab_hdf/contents.py
@@ -14,7 +14,7 @@ __all__ = ['HdfContentsManager', 'HdfContentsHandler']
 class HdfContentsManager(HdfFileManager):
     """Implements HDF5 contents handling
     """
-    def _getFromFile(self, f, uri, ixstr):
+    def _getFromFile(self, f, uri, ixstr, **kwargs):
         obj = f[uri]
 
         if isinstance(obj, h5py.Group):

--- a/jupyterlab_hdf/contents.py
+++ b/jupyterlab_hdf/contents.py
@@ -6,7 +6,7 @@
 import h5py
 
 from .baseHandler import HdfFileManager, HdfBaseHandler
-from .util import dsetContentDict, dsetDict, groupDict, uriJoin, uriName
+from .util import dsetContentDict, dsetDict, groupDict, jsonize, uriJoin, uriName
 
 __all__ = ['HdfContentsManager', 'HdfContentsHandler']
 
@@ -25,7 +25,7 @@ class HdfContentsManager(HdfFileManager):
             return dsetDict(
                 name=uriName(uri),
                 uri=uri,
-                content=dsetContentDict(obj, ixstr),
+                content=jsonize(dsetContentDict(obj, ixstr)),
             )
         else:
             raise ValueError("unknown h5py obj: %s" % obj)

--- a/jupyterlab_hdf/data.py
+++ b/jupyterlab_hdf/data.py
@@ -13,7 +13,7 @@ __all__ = ['HdfDataManager', 'HdfDataHandler']
 class HdfDataManager(HdfFileManager):
     """Implements HDF5 data handling
     """
-    def _getFromFile(self, f, uri, ixstr, subixstr, **kwargs):
+    def _getFromFile(self, f, uri, ixstr, subixstr=None, atleast_2d=False, **kwargs):
         # # DEBUG: uncomment for logging
         # from .util import dsetContentDict, parseSubindex
         # logd = dsetContentDict(f[uri], ixstr=ixstr)
@@ -22,7 +22,7 @@ class HdfDataManager(HdfFileManager):
         #     logd['ixcompound'] = parseSubindex(ixstr, subixstr, f[uri].shape)
         # self.log.info('{}'.format(logd))
 
-        return dsetChunk(f[uri], ixstr, subixstr)
+        return dsetChunk(f[uri], ixstr, subixstr=subixstr, atleast_2d=atleast_2d)
 
 
 ## handler

--- a/jupyterlab_hdf/data.py
+++ b/jupyterlab_hdf/data.py
@@ -22,7 +22,7 @@ class HdfDataManager(HdfFileManager):
         #     logd['ixcompound'] = parseSubindex(ixstr, subixstr, f[uri].shape)
         # self.log.info('{}'.format(logd))
 
-        return dsetChunk(f[uri], ixstr, subixstr=subixstr, atleast_2d=atleast_2d)
+        return dsetChunk(f[uri], ixstr, subixstr=subixstr, atleast_2d=atleast_2d).tolist()
 
 
 ## handler

--- a/jupyterlab_hdf/data.py
+++ b/jupyterlab_hdf/data.py
@@ -3,10 +3,8 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-import h5py
-
 from .baseHandler import HdfFileManager, HdfBaseHandler
-from .util import dsetChunk
+from .util import dsetChunk, dsetContentDict, parseSubindex
 
 __all__ = ['HdfDataManager', 'HdfDataHandler']
 
@@ -16,6 +14,13 @@ class HdfDataManager(HdfFileManager):
     """Implements HDF5 data handling
     """
     def _getFromFile(self, f, uri, ixstr, subixstr, **kwargs):
+        # uncomment for debug logging
+        logd = dsetContentDict(f[uri], ixstr=ixstr)
+        logd['subixstr'] = subixstr
+        if subixstr is not None:
+            logd['ixcompound'] = parseSubindex(ixstr, subixstr, f[uri].shape)
+        kwargs['log'].info('{}'.format(logd))
+
         return dsetChunk(f[uri], ixstr, subixstr)
 
 

--- a/jupyterlab_hdf/data.py
+++ b/jupyterlab_hdf/data.py
@@ -4,7 +4,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 from .baseHandler import HdfFileManager, HdfBaseHandler
-from .util import dsetChunk, dsetContentDict, parseSubindex
+from .util import dsetChunk
 
 __all__ = ['HdfDataManager', 'HdfDataHandler']
 
@@ -14,12 +14,13 @@ class HdfDataManager(HdfFileManager):
     """Implements HDF5 data handling
     """
     def _getFromFile(self, f, uri, ixstr, subixstr, **kwargs):
-        # uncomment for debug logging
-        logd = dsetContentDict(f[uri], ixstr=ixstr)
-        logd['subixstr'] = subixstr
-        if subixstr is not None:
-            logd['ixcompound'] = parseSubindex(ixstr, subixstr, f[uri].shape)
-        self.log.info('{}'.format(logd))
+        # # DEBUG: uncomment for logging
+        # from .util import dsetContentDict, parseSubindex
+        # logd = dsetContentDict(f[uri], ixstr=ixstr)
+        # logd['subixstr'] = subixstr
+        # if subixstr is not None:
+        #     logd['ixcompound'] = parseSubindex(ixstr, subixstr, f[uri].shape)
+        # self.log.info('{}'.format(logd))
 
         return dsetChunk(f[uri], ixstr, subixstr)
 

--- a/jupyterlab_hdf/data.py
+++ b/jupyterlab_hdf/data.py
@@ -15,8 +15,8 @@ __all__ = ['HdfDataManager', 'HdfDataHandler']
 class HdfDataManager(HdfFileManager):
     """Implements HDF5 data handling
     """
-    def _getFromFile(self, f, uri, row, col):
-        return dsetChunk(f[uri], row, col)
+    def _getFromFile(self, f, uri, ixstr):
+        return dsetChunk(f[uri], ixstr)
 
 
 ## handler

--- a/jupyterlab_hdf/data.py
+++ b/jupyterlab_hdf/data.py
@@ -15,8 +15,8 @@ __all__ = ['HdfDataManager', 'HdfDataHandler']
 class HdfDataManager(HdfFileManager):
     """Implements HDF5 data handling
     """
-    def _getFromFile(self, f, uri, ixstr):
-        return dsetChunk(f[uri], ixstr)
+    def _getFromFile(self, f, uri, ixstr, subixstr, **kwargs):
+        return dsetChunk(f[uri], ixstr, subixstr)
 
 
 ## handler

--- a/jupyterlab_hdf/data.py
+++ b/jupyterlab_hdf/data.py
@@ -19,7 +19,7 @@ class HdfDataManager(HdfFileManager):
         logd['subixstr'] = subixstr
         if subixstr is not None:
             logd['ixcompound'] = parseSubindex(ixstr, subixstr, f[uri].shape)
-        kwargs['log'].info('{}'.format(logd))
+        self.log.info('{}'.format(logd))
 
         return dsetChunk(f[uri], ixstr, subixstr)
 

--- a/jupyterlab_hdf/exception.py
+++ b/jupyterlab_hdf/exception.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+__all__ = ['JhdfError']
+
+class JhdfError(Exception):
+    pass

--- a/jupyterlab_hdf/snippet.py
+++ b/jupyterlab_hdf/snippet.py
@@ -18,7 +18,7 @@ dsetTemp = '''with h5py.File('{fpath}', 'r') as f:
 class HdfSnippetManager(HdfBaseManager):
     """Implements HDF5 contents handling
     """
-    def _get(self, fpath, uri, row, col):
+    def _get(self, fpath, uri, ixstr):
         return dsetTemp.format(fpath=fpath, uri=uri)
 
 

--- a/jupyterlab_hdf/snippet.py
+++ b/jupyterlab_hdf/snippet.py
@@ -18,7 +18,7 @@ dsetTemp = '''with h5py.File('{fpath}', 'r') as f:
 class HdfSnippetManager(HdfBaseManager):
     """Implements HDF5 contents handling
     """
-    def _get(self, fpath, uri, ixstr):
+    def _get(self, fpath, uri, ixstr, **kwargs):
         return dsetTemp.format(fpath=fpath, uri=uri)
 
 

--- a/jupyterlab_hdf/util.py
+++ b/jupyterlab_hdf/util.py
@@ -48,10 +48,10 @@ def dsetContentDict(dset, ixstr=None):
         *validateIxstr(ixstr, dset.shape),
     ))
 
-def dsetDict(name, uri, content=None):
+def dsetDict(uri, name=None, content=None):
     return dict((
         ('type', 'dataset'),
-        ('name', name),
+        ('name', uriName(name) if name is None else name),
         ('uri', uri),
         ('content', content),
     ))
@@ -172,8 +172,8 @@ def sliceLen(slyce, seqlen):
 def validateIxstr(ixstr, shape):
     ix = parseIndex(ixstr)
 
-    vislabels = getVislabels(ix, shape)
     visdims = getVisdims(ix)
+    vislabels = getVislabels(ix, shape)
     visshape = getVisshape(ix, shape)
 
     if len(visdims) != len(vislabels):
@@ -205,7 +205,9 @@ def parseSubindex(ixstr, subixstr, shape):
 
     ixcompound = list(ix)
     for d, dlabel, subdix in zip(visdims, vislabels, subix):
-        ixcompound[d] = slice(dlabel.start + (subdix.start * dlabel.step), dlabel.start + (subdix.stop * dlabel.step))
+        start = dlabel.start + (subdix.start*dlabel.step)
+        stop = dlabel.start + (min(subdix.stop, dlabel.stop // dlabel.step)*dlabel.step) # dlabel.start + (subdix.stop*dlabel.step)
+        ixcompound[d] = slice(start, stop)
 
     return tuple(ixcompound)
 

--- a/jupyterlab_hdf/util.py
+++ b/jupyterlab_hdf/util.py
@@ -24,7 +24,7 @@ def dsetChunk(dset, ixstr=None, subixstr=None, atleast_2d=False):
     if atleast_2d:
         chunk = np.atleast_2d(chunk)
 
-    return chunk.tolist()
+    return chunk
 
 
 ## create dicts to be returned by the contents api
@@ -38,10 +38,10 @@ def dsetContentDict(dset, ixstr=None):
         else:
             ixstr = ', '.join([':', ':'] + (['0'] * (dset.ndim - 2)))
 
-    ixmeta = jsonize(metadataIndex(ixstr, dset.shape))
+    ixmeta = metadataIndex(ixstr, dset.shape)
 
     return dict((
-        ('attrs', {k: jsonize(v) for k, v in dset.attrs.items()}),
+        ('attrs', {**dset.attrs}),
         ('dtype', dset.dtype.str),
         ('shape', dset.shape),
         ('ixstr', ixstr),

--- a/jupyterlab_hdf/util.py
+++ b/jupyterlab_hdf/util.py
@@ -3,11 +3,12 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import ast
 import re
 import numpy as np
 
 
-__all__ = ['chunkSlice', 'dsetChunk', 'dsetContentDict', 'dsetDict', 'groupDict', 'uriJoin', 'uriName']
+__all__ = ['chunkSlice', 'dsetChunk', 'dsetContentDict', 'dsetDict', 'groupDict', 'parseIndex', 'uriJoin', 'uriName']
 
 ## chunk handling
 def chunkSlice(chunk, s):
@@ -16,8 +17,8 @@ def chunkSlice(chunk, s):
 
     return slice(s.start*chunk, s.stop*chunk, s.step)
 
-def dsetChunk(dset, row, col):
-    return dset[slice(*row), slice(*col)].tolist()
+def dsetChunk(dset, ixstr):
+    return dset[parseIndex(ixstr)].tolist()
 
 
 def serialize_value(v):
@@ -33,7 +34,7 @@ def serialize_value(v):
     return v
 
 ## create dicts to be converted to json
-def dsetContentDict(dset, row=None, col=None):
+def dsetContentDict(dset, ixstr=None):
     return dict([
         # metadata
         ('attrs', {k: serialize_value(v) for k, v in dset.attrs.items()}),
@@ -42,7 +43,7 @@ def dsetContentDict(dset, row=None, col=None):
         ('shape', dset.shape),
 
         # actual data
-        ('data', dsetChunk(dset, row, col) if row and col else None)
+        ('data', dsetChunk(dset, ixstr) if ixstr is not None else None)
     ])
 
 def dsetDict(name, uri, content=None):
@@ -60,6 +61,89 @@ def groupDict(name, uri):
         ('uri', uri),
         ('content', None)
     ])
+
+
+## index parsing
+class _Guard:
+    def __init__(self):
+        self.val = False
+
+    def __call__(self):
+        if self.val:
+            return True
+        else:
+            self.val = True
+            return False
+
+def parseIndex(node_or_string):
+    """
+    "Safely" (needs validation) evaluate an expression node or a string containing
+    a (limited subset) of valid numpy index or slice expressions.
+    """
+    if isinstance(node_or_string, str):
+        node_or_string = ast.parse('dummy[{}]'.format(node_or_string.lstrip(" \t")) , mode='eval')
+    if isinstance(node_or_string, ast.Expression):
+        node_or_string = node_or_string.body
+    if isinstance(node_or_string, ast.Subscript):
+        node_or_string = node_or_string.slice
+
+    def _raise_malformed_node(node):
+        raise ValueError('malformed node or string: {}, {}'.format(node, ast.dump(node)))
+    def _raise_nested_tuple_node(node):
+        raise ValueError('tuples inside of tuple indices are not supported: {}, {}'.format(node, ast.dump(node)))
+
+    # from cpy37, should work until they remove ast.Num (not until cpy310)
+    def _convert_num(node):
+        if isinstance(node, ast.Constant):
+            if isinstance(node.value, (int, float, complex)):
+                return node.value
+        elif isinstance(node, ast.Num):
+            # ast.Num was removed from ast grammar in cpy38
+            return node.n # pragma: no cover
+        _raise_malformed_node(node)
+    def _convert_signed_num(node):
+        if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.UAdd, ast.USub)):
+            operand = _convert_num(node.operand)
+            if isinstance(node.op, ast.UAdd):
+                return + operand
+            else:
+                return - operand
+        return _convert_num(node)
+
+    _nested_tuple_guard = _Guard()
+    def _convert(node):
+        if isinstance(node, ast.Tuple):
+            if _nested_tuple_guard():
+                _raise_nested_tuple_node(node)
+
+            return tuple(map(_convert, node.elts))
+        elif isinstance(node, ast.Slice):
+            return slice(
+                _convert(node.lower) if node.lower is not None else None,
+                _convert(node.upper) if node.upper is not None else None,
+                # for now, no step support
+                # _convert(node.step) if node.step is not None else None,
+                None,
+            )
+        elif isinstance(node, ast.NameConstant) and node.value is None:
+            # support for literal None in slices, eg 'slice(None, ...)'
+            return None
+        elif isinstance(node, ast.Ellipsis):
+            # support for three dot '...' ellipsis syntax
+            return ...
+        elif isinstance(node, ast.Name) and node.id == 'Ellipsis':
+            # support for 'Ellipsis' ellipsis syntax
+            return ...
+        elif isinstance(node, ast.Index):
+            # ast.Index was removed from ast grammar in cpy39
+            return _convert(node.value) # pragma: no cover
+        elif isinstance(node, ast.ExtSlice):
+            # ast.ExtSlice was removed from ast grammar in cpy39
+            _nested_tuple_guard() # pragma: no cover
+            return tuple(map(_convert, node.dims))
+
+        return _convert_signed_num(node)
+    return _convert(node_or_string)
 
 
 ## uri handling

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
   "author": "Project Jupyter",
   "files": [
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
+    "schema/**/*.{json,}",
+    "src/**/*.{js,jsx,ts,tsx}",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
   ],
   "main": "lib/index.js",

--- a/scratch/genNested.py
+++ b/scratch/genNested.py
@@ -47,4 +47,5 @@ def genNested(name, N=None, ext=None, fillRange=False, func=None, shape=None, su
 
 if __name__=='__main__':
     genNested('nested', shape=(10,10))
+#     genNested('nested_int_one_d', N=2, fillRange=True, shape=(1000,)*1)
 #     genNested('nested_int_high_d', N=2, fillRange=True, shape=(50,)*4)

--- a/scratch/nested-meta.ipynb
+++ b/scratch/nested-meta.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -19,11 +19,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
-    "genNested()"
+    "# genNested('nested', shape=(10,10))\n",
+    "genNested('nested_int_one_d', N=2, fillRange=True, shape=(1000,)*1)\n",
+    "# genNested('nested_int_high_d', N=2, fillRange=True, shape=(50,)*4)"
    ]
   },
   {
@@ -253,7 +255,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.7",
    "language": "python",
    "name": "python3"
   },
@@ -267,7 +269,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.9"
   }
  },
  "nbformat": 4,

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup_dict = dict(
     license         = 'BSD',
     platforms       = "Linux, Mac OS X, Windows",
     keywords        = ['Jupyter', 'JupyterLab', 'hdf5'],
-    python_requires = '>=3.5',
+    python_requires = '>=3.6',
     classifiers     = [
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,8 @@ setup_dict = dict(
     ],
     install_requires=[
         'h5py',
-        'notebook'
+        'notebook',
+        'simplejson'
     ]
 )
 

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -23,7 +23,7 @@ const DATA_MIME = "application/x-hdf5.dataset";
 export class HdfSidepanel extends Widget {
   constructor(browser: FileBrowser, drive: HdfDrive) {
     super();
-    this.addClass("jp-HdfSidepanel");
+    this.addClass("jhdf-sidepanel");
     this.layout = new PanelLayout();
     (this.layout as PanelLayout).addWidget(browser);
     this._browser = browser;
@@ -46,7 +46,7 @@ export class HdfSidepanel extends Widget {
     //   },
     //   tooltip: 'Refresh File List'
     // });
-    // refresher.addClass('jp-Hdf-toolbar-item');
+    // refresher.addClass('jhdf-toolbar-item');
     // this._browser.toolbar.addItem('gh-refresher', refresher);
   }
 
@@ -181,13 +181,13 @@ export class hdfFpathInput extends Widget {
     super();
     this._browser = browser;
 
-    this.addClass("jp-HdfUserInput");
+    this.addClass("jhdf-userInput");
     const layout = (this.layout = new PanelLayout());
     const wrapper = new Widget();
-    wrapper.addClass("jp-HdfUserInput-wrapper");
+    wrapper.addClass("jhdf-userInput-wrapper");
     this._input = document.createElement("input");
     this._input.placeholder = "HDF5 Path";
-    this._input.className = "jp-HdfUserInput-input";
+    this._input.className = "jhdf-userInput-input";
     wrapper.node.appendChild(this._input);
     layout.addWidget(wrapper);
 
@@ -312,11 +312,11 @@ export class hdfFpathInput extends Widget {
 export class HdfErrorPanel extends Widget {
   constructor(message: string) {
     super();
-    this.addClass("jp-HdfErrorPanel");
+    this.addClass("jhdf-errorPanel");
     const image = document.createElement("div");
     const text = document.createElement("div");
-    image.className = "jp-HdfErrorImage";
-    text.className = "jp-HdfErrorText";
+    image.className = "jhdf-errorPanel-image";
+    text.className = "jhdf-errorPanel-text";
     text.textContent = message;
     this.node.appendChild(image);
     this.node.appendChild(text);

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -37,9 +37,10 @@ import {
   IDatasetMeta,
   parseHdfQuery
 } from "./hdf";
-import { IxInput } from "./toolbar";
 
 import { ISlice, noneSlice } from "./slice";
+
+import { IxInput } from "./toolbar";
 
 /**
  * The CSS class for the data grid widget.

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -89,10 +89,10 @@ export class HdfDatasetModelBase extends DataModel {
 
   data(region: DataModel.CellRegion, row: number, col: number): any {
     if (region === "row-header") {
-      return `${this._rowslice.start + row * this._rowslice.step}`;
+      return `${this._slice[0].start + row * this._slice[0].step}`;
     }
     if (region === "column-header") {
-      return `${this._colslice.start + col * this._colslice.step}`;
+      return `${this._slice[1].start + col * this._slice[1].step}`;
     }
     if (region === "corner-header") {
       return null;
@@ -137,27 +137,27 @@ export class HdfDatasetModelBase extends DataModel {
     if (this._meta.visshape.length < 1) {
       // for 0d (scalar), use (1, 1)
       this._hassubix = [false, false];
-      [this._nrowheader, this._ncolheader] = [0, 0];
-      [this._nrow, this._ncol] = [1, 1];
-      [this._rowslice, this._colslice] = [slice(0, 1), slice(0, 1)];
+      this._n = [1, 1];
+      this._nheader = [0, 0];
+      this._slice = [slice(0, 1), slice(0, 1)];
     } else if (this._meta.vissize <= 0) {
       // for 0d (empty), use (0, 0)
       this._hassubix = [false, false];
-      [this._nrowheader, this._ncolheader] = [0, 0];
-      [this._nrow, this._ncol] = [0, 0];
-      [this._rowslice, this._colslice] = [noneSlice(), noneSlice()];
+      this._n = [0, 0];
+      this._nheader = [0, 0];
+      this._slice = [noneSlice(), noneSlice()];
     } else if (this._meta.visshape.length < 2) {
       // for 1d, use (1, size)
       this._hassubix = [false, true];
-      [this._nrow, this._ncol] = [1, this._meta.vissize];
-      [this._nrowheader, this._ncolheader] = [1, 0];
-      [this._rowslice, this._colslice] = [slice(0, 1), this._meta.vislabels[0]];
+      this._n = [1, this._meta.vissize];
+      this._nheader = [1, 0];
+      this._slice = [slice(0, 1), this._meta.vislabels[0]];
     } else {
       // for 2d up, use standard shape
       this._hassubix = [true, true];
-      [this._nrow, this._ncol] = this._meta.visshape;
-      [this._nrowheader, this._ncolheader] = [1, 1];
-      [this._rowslice, this._colslice] = this._meta.vislabels;
+      this._n = this._meta.visshape;
+      this._nheader = [1, 1];
+      this._slice = this._meta.vislabels;
     }
   }
 
@@ -238,17 +238,17 @@ export class HdfDatasetModelBase extends DataModel {
 
   rowCount(region: DataModel.RowRegion): number {
     if (region === "body") {
-      return this._nrow;
+      return this._n[0];
     }
 
-    return this._nrowheader;
+    return this._nheader[0];
   }
   columnCount(region: DataModel.ColumnRegion): number {
     if (region === "body") {
-      return this._ncol;
+      return this._n[1];
     }
 
-    return this._ncolheader;
+    return this._nheader[1];
   }
 
   /**
@@ -317,14 +317,12 @@ export class HdfDatasetModelBase extends DataModel {
   protected _uri: string = "";
   protected _meta: IDatasetMeta;
 
-  protected _hassubix = [false, false];
   protected _ixstr: string = "";
-  protected _nrow = 0;
-  protected _ncol = 0;
-  protected _nrowheader = 0;
-  protected _ncolheader = 0;
-  protected _rowslice = noneSlice();
-  protected _colslice = noneSlice();
+
+  protected _hassubix = [false, false];
+  protected _n = [0, 0];
+  protected _nheader = [0, 0];
+  protected _slice = [noneSlice(), noneSlice()];
 
   private _blocks: any = Object();
   private _blockSize: number = 100;

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -40,7 +40,7 @@ import {
   parseHdfQuery
 } from "./hdf";
 
-import { ISlice, noneSlice } from "./slice";
+import { noneSlice } from "./slice";
 
 import { IxInput } from "./toolbar";
 
@@ -89,10 +89,10 @@ export class HdfDatasetModelBase extends DataModel {
 
   data(region: DataModel.CellRegion, row: number, col: number): any {
     if (region === "row-header") {
-      return `${this.rowSlice.start + row * this.rowSlice.step}`;
+      return `${this._rowslice.start + row * this._rowslice.step}`;
     }
     if (region === "column-header") {
-      return `${this.colSlice.start + col * this.colSlice.step}`;
+      return `${this._colslice.start + col * this._colslice.step}`;
     }
     if (region === "corner-header") {
       return null;
@@ -136,12 +136,15 @@ export class HdfDatasetModelBase extends DataModel {
     if (this._meta.vissize <= 0) {
       // if size <= 0, use empty shape
       [this._nrow, this._ncol] = [0, 0];
+      [this._rowslice, this._colslice] = [noneSlice(), noneSlice()];
     } else if (this._meta.visshape.length >= 2) {
       // for 2d, use standard shape
       [this._nrow, this._ncol] = this._meta.visshape;
+      [this._rowslice, this._colslice] = this._meta.vislabels;
     } else {
       // for 0d or 1d, use (1, size)
       [this._nrow, this._ncol] = [1, this._meta.vissize];
+      [this._rowslice, this._colslice] = [noneSlice(), ...this._meta.vislabels];
     }
   }
 
@@ -233,13 +236,6 @@ export class HdfDatasetModelBase extends DataModel {
     return 1;
   }
 
-  get rowSlice(): ISlice {
-    return this._meta?.vislabels[0] || noneSlice();
-  }
-  get colSlice(): ISlice {
-    return this._meta?.vislabels[1] || noneSlice();
-  }
-
   /**
    * fetch a data block. When data is received,
    * the grid will be updated by emitChanged.
@@ -307,6 +303,8 @@ export class HdfDatasetModelBase extends DataModel {
   protected _ixstr: string = "";
   protected _ncol = 0;
   protected _nrow = 0;
+  protected _colslice = noneSlice();
+  protected _rowslice = noneSlice();
 
   private _blocks: any = Object();
   private _blockSize: number = 100;

--- a/src/exception.tsx
+++ b/src/exception.tsx
@@ -1,0 +1,54 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { Dialog, showDialog } from "@jupyterlab/apputils";
+import { ServerConnection } from "@jupyterlab/services";
+import { ReadonlyJSONObject } from "@lumino/coreutils";
+
+import * as React from "react";
+
+const HDF_MODAL_TEXT_CLASS = "jhdf-errorModal-text";
+
+export class HdfResponseError extends ServerConnection.ResponseError {
+  /**
+   * Create a new response error.
+   */
+  constructor({
+    response,
+    message = `Invalid response: ${response.status} ${response.statusText}`,
+    debugVars = {},
+    traceback = ""
+  }: {
+    response: Response;
+    message: string;
+    debugVars: ReadonlyJSONObject;
+    traceback: string;
+  }) {
+    super(response, message);
+    this.debugVars = debugVars;
+    this.traceback = traceback;
+  }
+
+  debugVars: ReadonlyJSONObject;
+  traceback: string;
+}
+
+export function modalHdfError(
+  error: HdfResponseError,
+  buttons: ReadonlyArray<Dialog.IButton> = [
+    Dialog.okButton({ label: "Dismiss" })
+  ]
+) {
+  const { message, debugVars, traceback } = error;
+  console.warn({ message, debugVars, traceback });
+
+  return showDialog({
+    title: "jupyterlab-hdf error",
+    body: (
+      <div className={HDF_MODAL_TEXT_CLASS}>
+        <div>{message}</div>
+      </div>
+    ),
+    buttons: buttons
+  });
+}

--- a/src/hdf.ts
+++ b/src/hdf.ts
@@ -68,11 +68,11 @@ export function hdfContentsRequest(
   settings: ServerConnection.ISettings
 ): Promise<HdfDirectoryListing | HdfContents> {
   // allow the query parameters to be optional
-  const { fpath, uri } = parameters;
+  const { fpath, uri, ixstr } = parameters;
 
   const fullUrl =
     URLExt.join(settings.baseUrl, "hdf", "contents", fpath).split("?")[0] +
-    objectToQueryString({ uri });
+    objectToQueryString({ uri, ixstr });
 
   return hdfApiRequest(fullUrl, {}, settings);
 }

--- a/src/hdf.ts
+++ b/src/hdf.ts
@@ -87,11 +87,11 @@ export function hdfDataRequest(
   settings: ServerConnection.ISettings
 ): Promise<number[][]> {
   // require the uri, row, and col query parameters
-  const { fpath, uri, ixstr, subixstr } = parameters;
+  const { fpath, uri, ixstr, atleast_2d, subixstr } = parameters;
 
   const fullUrl =
     URLExt.join(settings.baseUrl, "hdf", "data", fpath).split("?")[0] +
-    objectToQueryString({ uri, ixstr, subixstr });
+    objectToQueryString({ uri, ixstr, atleast_2d, subixstr });
 
   return hdfApiRequest(fullUrl, {}, settings);
 }
@@ -195,6 +195,8 @@ export interface IContentsParameters {
 }
 
 export interface IDataParameters extends IContentsParameters {
+  atleast_2d?: boolean;
+
   subixstr?: string;
 }
 
@@ -224,9 +226,9 @@ export class HdfContents {
 }
 
 export interface IDatasetMeta {
-  dtype: string;
+  attrs: { [key: string]: any };
 
-  ndim: number;
+  dtype: string;
 
   shape: number[];
 
@@ -234,11 +236,9 @@ export interface IDatasetMeta {
 
   vislabels: ISlice[];
 
-  visdims: number[];
-
   visshape: number[];
 
-  attrs: { [key: string]: any };
+  vissize: number;
 }
 
 /**

--- a/src/hdf.ts
+++ b/src/hdf.ts
@@ -78,24 +78,6 @@ export function hdfContentsRequest(
 }
 
 /**
- * Send a parameterized request to the `hdf/ix` api, and
- * return the result.
- */
-export function hdfIxRequest(
-  parameters: IIxParameters,
-  settings: ServerConnection.ISettings
-): Promise<IIxMeta> {
-  // require the uri, row, and col query parameters
-  const { fpath, uri, ixstr } = parameters;
-
-  const fullUrl =
-    URLExt.join(settings.baseUrl, "hdf", "ix", fpath).split("?")[0] +
-    objectToQueryString({ uri, ixstr });
-
-  return hdfApiRequest(fullUrl, {}, settings);
-}
-
-/**
  * Send a parameterized request to the `hdf/data` api, and
  * return the result.
  */
@@ -163,13 +145,11 @@ export interface IContentsParameters {
    * Path within an HDF5 file to a specific group or dataset.
    */
   uri: string;
-}
 
-export interface IIxParameters extends IContentsParameters {
   ixstr?: string;
 }
 
-export interface IDataParameters extends IIxParameters {
+export interface IDataParameters extends IContentsParameters {
   subixstr?: string;
 }
 
@@ -207,13 +187,11 @@ export interface IDatasetMeta {
 
   ixstr: string;
 
+  visdims: number[];
+
+  ixlabels: ISlice[];
+
   attrs: { [key: string]: any };
-}
-
-export interface IIxMeta {
-  dims: number[];
-
-  slices: ISlice[];
 }
 
 /**

--- a/src/hdf.ts
+++ b/src/hdf.ts
@@ -187,9 +187,11 @@ export interface IDatasetMeta {
 
   ixstr: string;
 
+  vislabels: ISlice[];
+
   visdims: number[];
 
-  ixlabels: ISlice[];
+  visshape: number[];
 
   attrs: { [key: string]: any };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,21 +36,21 @@ import {
 } from "./hdf";
 
 /**
- * Hdf plugins state namespace.
+ * hdf plugins state namespace
  */
 const HDF_BROWSER_NAMESPACE = "hdf-file-browser";
 const HDF_FILE_BROWSER_NAMESPACE = "hdf-filebrowser";
 const HDF_DATASET_NAMESPACE = "hdf-dataset";
 
 /**
- * The IDs for the plugins.
+ * the IDs for the plugins
  */
 const hdf5BrowserPluginId = "jupyterlab-hdf:browser";
 const hdf5DatasetPluginId = "jupyterlab-hdf:dataset";
 // const hdf5DataRegistryPluginId = "jupyterlab-hdf:dataregistry";
 
 /**
- * Hdf icon classnames
+ * hdf icon classnames
  */
 const HDF_ICON = "jp-HdfIcon";
 const HDF_FILE_ICON = `jp-MaterialIcon ${HDF_ICON}`;
@@ -58,7 +58,7 @@ const HDF_DATASET_ICON = "jp-MaterialIcon jp-SpreadsheetIcon"; // jp-HdfDatasetI
 
 namespace CommandIDs {
   /**
-   * Fetch metadata from an hdf5 file
+   * fetch metadata from an hdf5 file
    */
   export const fetchContents = "hdf:fetch-contents";
 
@@ -68,9 +68,9 @@ namespace CommandIDs {
 }
 
 /**
- * Initialization data for the jupyterlab-hdf5 extension.
+ * initialization data for the jupyterlab-hdf5 extension
  */
-const hdfBrowserExtension: JupyterFrontEndPlugin<void> = {
+const hdfBrowserPlugin: JupyterFrontEndPlugin<void> = {
   id: hdf5BrowserPluginId,
   requires: [
     IDocumentManager,
@@ -85,7 +85,7 @@ const hdfBrowserExtension: JupyterFrontEndPlugin<void> = {
 };
 
 /**
- * The HTML file handler extension.
+ * the HTML file handler extension
  */
 const hdfDatasetPlugin: JupyterFrontEndPlugin<IHdfDatasetDocTracker> = {
   id: hdf5DatasetPluginId,
@@ -109,7 +109,7 @@ const hdfDatasetPlugin: JupyterFrontEndPlugin<IHdfDatasetDocTracker> = {
 // };
 
 /**
- * Activate the file browser.
+ * activate the hdf file browser extension
  */
 function activateHdfBrowserPlugin(
   app: JupyterFrontEnd,
@@ -299,7 +299,7 @@ function addBrowserCommands(
 }
 
 /**
- * Activate the HTMLViewer extension.
+ * activate the hdf dataset viewer extension
  */
 function activateHdfDatasetPlugin(
   app: JupyterFrontEnd,
@@ -356,7 +356,7 @@ function activateHdfDatasetPlugin(
 }
 
 // /**
-//  * Activate the HTMLViewer extension.
+//  * activate the hdf dataregistry extension
 //  */
 // function activateHdfDataRegistryPlugin(
 //   app: JupyterFrontEnd,
@@ -371,10 +371,10 @@ function activateHdfDatasetPlugin(
 // }
 
 /**
- * Export the plugins as default.
+ * export the plugins as default
  */
 const plugins: JupyterFrontEndPlugin<any>[] = [
-  hdfBrowserExtension,
+  hdfBrowserPlugin,
   hdfDatasetPlugin
   // hdfDataRegistryPlugin
 ];

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,9 +52,9 @@ const hdf5DatasetPluginId = "jupyterlab-hdf:dataset";
 /**
  * hdf icon classnames
  */
-const HDF_ICON = "jp-HdfIcon";
+const HDF_ICON = "jhdf-icon";
 const HDF_FILE_ICON = `jp-MaterialIcon ${HDF_ICON}`;
-const HDF_DATASET_ICON = "jp-MaterialIcon jp-SpreadsheetIcon"; // jp-HdfDatasetIcon;
+const HDF_DATASET_ICON = "jp-MaterialIcon jp-SpreadsheetIcon"; // jhdf-datasetIcon;
 
 namespace CommandIDs {
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -230,12 +230,6 @@ function addBrowserCommands(
         fpath: args["fpath"] as string,
         uri: args["uri"] as string
       };
-      if (args["col"]) {
-        params.col = args["col"] as number[];
-      }
-      if (args["row"]) {
-        params.row = args["row"] as number[];
-      }
 
       return hdfContentsRequest(params, serverSettings);
     },

--- a/src/slice.ts
+++ b/src/slice.ts
@@ -7,14 +7,16 @@ export interface ISlice {
   step?: number | null;
 }
 
-const allSlices: ISlice[] = [
-  { start: null, stop: null },
-  { start: null, stop: null }
-];
-const noneSlices: ISlice[] = [
-  { start: 0, stop: 0 },
-  { start: 0, stop: 0 }
-];
+export function allSlice(): ISlice {
+  return { start: null, stop: null, step: 1 };
+}
+
+export function noneSlice(): ISlice {
+  return { start: 0, stop: 0, step: 1 };
+}
+
+const allSlices: ISlice[] = [allSlice(), allSlice()];
+const noneSlices: ISlice[] = [noneSlice(), noneSlice()];
 
 export const parseSlices = (strSlices: string): ISlice[] => {
   if (!strSlices) {

--- a/src/slice.ts
+++ b/src/slice.ts
@@ -7,12 +7,27 @@ export interface ISlice {
   step?: number | null;
 }
 
+/**
+ * analagous to the python `slice` constructor
+ */
+export function slice(
+  start: number | null,
+  stop?: number | null,
+  step: number | null = null
+): ISlice {
+  if (stop === undefined) {
+    return { start: 0, stop: start, step: 1 };
+  }
+
+  return { start, stop, step: step === null ? 1 : step };
+}
+
 export function allSlice(): ISlice {
-  return { start: null, stop: null, step: 1 };
+  return slice(null, null);
 }
 
 export function noneSlice(): ISlice {
-  return { start: 0, stop: 0, step: 1 };
+  return slice(0, 0);
 }
 
 const allSlices: ISlice[] = [allSlice(), allSlice()];

--- a/src/slice.ts
+++ b/src/slice.ts
@@ -11,7 +11,10 @@ const allSlices: ISlice[] = [
   { start: null, stop: null },
   { start: null, stop: null }
 ];
-const noneSlices: ISlice[] = [{ start: 0, stop: 0 }, { start: 0, stop: 0 }];
+const noneSlices: ISlice[] = [
+  { start: 0, stop: 0 },
+  { start: 0, stop: 0 }
+];
 
 export const parseSlices = (strSlices: string): ISlice[] => {
   if (!strSlices) {
@@ -40,7 +43,7 @@ export const parseSlices = (strSlices: string): ISlice[] => {
       `Error parsing slices: invalid slices string input. strSlices: "${strSlices}"`
     );
 
-    return noneSlices;
+    return [...noneSlices];
   }
 
   return slices;

--- a/src/toolbar.tsx
+++ b/src/toolbar.tsx
@@ -9,22 +9,22 @@ import { ReactWidget } from "@jupyterlab/apputils";
 
 import { HdfDatasetModelBase } from "./dataset";
 
-const TOOLBAR_SLICEINPUT_CLASS = ".jp-SliceInputToolbar";
-const TOOLBAR_SLICEINPUT_BOX_CLASS = ".jp-SliceInputToolbar-box";
+const TOOLBAR_IX_INPUT_CLASS = ".jp-IxInputToolbar";
+const TOOLBAR_IX_INPUT_BOX_CLASS = ".jp-IxInputToolbar-box";
 
 /**
- * A namespace for SliceInput statics.
+ * A namespace for IxInput statics.
  */
-namespace SliceInput {
+namespace IxInput {
   /**
-   * The props for SliceInput.
+   * The props for IxInput.
    */
   export interface IProps {
     handleEnter: (val: string) => void;
   }
 
   /**
-   * The props for SliceInput.
+   * The props for IxInput.
    */
   export interface IState {
     /**
@@ -39,34 +39,34 @@ namespace SliceInput {
   }
 }
 
-export class SliceInput extends ReactWidget {
+export class IxInput extends ReactWidget {
   /**
    * Construct a new text input for a slice.
    */
   constructor(widget: DataGrid) {
     super();
-    this.addClass(TOOLBAR_SLICEINPUT_CLASS);
+    this.addClass(TOOLBAR_IX_INPUT_CLASS);
 
     this._grid = widget;
     this._model = this._grid.dataModel as HdfDatasetModelBase;
   }
 
   render() {
-    return <SliceInputBox handleEnter={val => (this._model.slice = val)} />;
+    return <IxInputBox handleEnter={val => (this._model.ixstr = val)} />;
   }
 
   private _grid: DataGrid;
   private _model: HdfDatasetModelBase;
 }
 
-export class SliceInputBox extends React.Component<
-  SliceInput.IProps,
-  SliceInput.IState
+export class IxInputBox extends React.Component<
+  IxInput.IProps,
+  IxInput.IState
 > {
   /**
    * Construct a new cell type switcher.
    */
-  constructor(props: SliceInput.IProps) {
+  constructor(props: IxInput.IProps) {
     super(props);
     this.state = {
       value: ":, :",
@@ -119,7 +119,7 @@ export class SliceInputBox extends React.Component<
         {"Slice: "}
         <input
           type="text"
-          className={TOOLBAR_SLICEINPUT_BOX_CLASS}
+          className={TOOLBAR_IX_INPUT_BOX_CLASS}
           onChange={this._handleChange}
           onFocus={this._handleFocus}
           onBlur={this._handleBlur}

--- a/src/toolbar.tsx
+++ b/src/toolbar.tsx
@@ -15,31 +15,42 @@ const TOOLBAR_IX_INPUT_CLASS = ".jp-IxInputToolbar";
 const TOOLBAR_IX_INPUT_BOX_CLASS = ".jp-IxInputToolbar-box";
 
 /**
- * A namespace for IxInput statics.
+ * a namespace for IxInputBox statics
  */
 namespace IxInputBox {
   /**
-   * The props for IxInput.
+   * the props for IxInputBox
    */
   export interface IProps {
+    /**
+     * function run when enter key is pressed in input box
+     */
     handleEnter: (val: string) => void;
 
-    initialValue: string;
+    /**
+     * initial value shown in input box
+     */
+    initialValue?: string;
 
+    /**
+     * signal by which input value can be updated.
+     * Updates the value in an isolated way, without
+     * triggering eg handleEnter
+     */
     signal: ISignal<any, string>;
   }
 
   /**
-   * The props for IxInput.
+   * the state for IxInputBox
    */
   export interface IState {
     /**
-     * The current value of the form.
+     * the current value of the input box
      */
     value: string;
 
     /**
-     * Whether the form has focus.
+     * whether the input box has focus
      */
     hasFocus: boolean;
   }
@@ -47,7 +58,7 @@ namespace IxInputBox {
 
 export class IxInput extends ReactWidget {
   /**
-   * Construct a new text input for a slice.
+   * construct a new text input for an index
    */
   constructor(widget: DataGrid) {
     super();
@@ -76,18 +87,18 @@ export class IxInputBox extends React.Component<
   IxInputBox.IState
 > {
   /**
-   * Construct a new cell type switcher.
+   * construct a new input box for an index
    */
   constructor(props: IxInputBox.IProps) {
     super(props);
     this.state = {
-      value: this.props.initialValue,
+      value: this.props.initialValue || "",
       hasFocus: false
     };
   }
 
   /**
-   * Attach the value change signal and focus the element on mount.
+   * attach the value change signal and focus the element on mount
    */
   componentDidMount() {
     this.props.signal.connect(this._slot);
@@ -102,7 +113,7 @@ export class IxInputBox extends React.Component<
   }
 
   /**
-   * Handle `keydown` events for the HTMLSelect component.
+   * handle `keydown` events for the HTMLSelect component
    */
   private _handleKeyDown = (
     event: React.KeyboardEvent<HTMLInputElement>
@@ -113,26 +124,29 @@ export class IxInputBox extends React.Component<
   };
 
   /**
-   * Handle a change to the value in the input field.
+   * handle a change to the value in the input field
    */
   private _handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     this.setState({ value: event.currentTarget.value });
   };
 
   /**
-   * Handle focusing of the input field.
+   * handle focusing of the input field
    */
   private _handleFocus = () => {
     this.setState({ hasFocus: true });
   };
 
   /**
-   * Handle blurring of the input field.
+   * handle blurring of the input field
    */
   private _handleBlur = () => {
     this.setState({ hasFocus: false });
   };
 
+  /**
+   * update value on signal emit
+   */
   private _slot = (_: any, args: string) => {
     // skip setting new state if incoming val is equal to existing value
     if (args === this.state.value) {

--- a/style/index.css
+++ b/style/index.css
@@ -3,25 +3,25 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
-.jp-HdfIcon {
+.jhdf-icon {
   background-image: url(hdf.svg);
 }
 
-.jp-HdfDatasetIcon {
+.jhdf-datasetIcon {
   background-image: url(dataset.svg);
 }
 
-.jp-HdfSidepanel {
+.jhdf-sidepanel {
   background-color: var(--jp-layout-color1);
   height: 100%;
 }
 
-.jp-HdfSidepanel .jp-FileBrowser {
+.jhdf-sidepanel .jp-FileBrowser {
   flex-grow: 1;
   height: 100%;
 }
 
-.jp-HdfUserInput {
+.jhdf-userInput {
   overflow: hidden;
   white-space: nowrap;
   text-align: center;
@@ -30,11 +30,11 @@
   background-color: var(--jp-layout-color1);
 }
 
-.jp-FileBrowser-toolbar.jp-Toolbar .jp-Toolbar-item.jp-HdfUserInput {
+.jp-FileBrowser-toolbar.jp-Toolbar .jp-Toolbar-item.jhdf-userInput {
   flex: 8 8;
 }
 
-.jp-HdfUserInput-wrapper {
+.jhdf-userInput-wrapper {
   background-color: var(--jp-input-active-background);
   border: var(--jp-border-width) solid var(--jp-border-color2);
   height: 30px;
@@ -43,12 +43,12 @@
   margin: 0 4px 0 0;
 }
 
-.jp-HdfUserInput-wrapper:focus-within {
+.jhdf-userInput-wrapper:focus-within {
   border: var(--jp-border-width) solid var(--md-blue-500);
   box-shadow: inset 0 0 4px var(--md-blue-300);
 }
 
-.jp-HdfUserInput-wrapper input {
+.jhdf-userInput-wrapper input {
   background: transparent;
   float: left;
   border: none;
@@ -59,29 +59,29 @@
   line-height: 28px;
 }
 
-.jp-HdfUserInput-wrapper input::placeholder {
+.jhdf-userInput-wrapper input::placeholder {
   color: var(--jp-ui-font-color3);
   font-size: var(--jp-ui-font-size1);
   text-transform: uppercase;
 }
 
-.jp-HdfSidepanel .jp-ToolbarButton.jp-Toolbar-item.jp-Hdf-toolbar-item {
+.jhdf-sidepanel .jp-ToolbarButton.jp-Toolbar-item.jhdf-toolbar-item {
   display: block;
 }
 
-.jp-HdfSidepanel .jp-ToolbarButton.jp-Toolbar-item {
+.jhdf-sidepanel .jp-ToolbarButton.jp-Toolbar-item {
   display: none;
 }
 
-.jp-HdfSidepanel .jp-DirListing-headerItem.jp-id-modified {
+.jhdf-sidepanel .jp-DirListing-headerItem.jp-id-modified {
   display: none;
 }
 
-.jp-HdfSidepanel .jp-DirListing-itemModified {
+.jhdf-sidepanel .jp-DirListing-itemModified {
   display: none;
 }
 
-.jp-HdfErrorPanel {
+.jhdf-errorPanel {
   position: absolute;
   display: flex;
   flex-direction: column;
@@ -95,16 +95,20 @@
   background: var(--jp-layout-color2);
 }
 
-.jp-HdfErrorImage {
+.jhdf-errorPanel-image {
   background-size: 100%;
   width: 200px;
   height: 165px;
   background-image: url(bad.svg);
 }
 
-.jp-HdfErrorText {
+.jhdf-errorPanel-text {
   font-size: var(--jp-ui-font-size3);
   color: var(--jp-ui-font-color1);
   text-align: center;
   padding: 12px;
+}
+
+.jhdf-errorModal-text {
+  white-space: pre-line;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfigbase",
   "compilerOptions": {
-    "inlineSources": true,
+    // "inlineSources": true,
     "outDir": "lib",
-    "rootDir": "src",
-    "sourceRoot": "./@jupyterlab/hdf5/src"
+    "rootDir": "src"
+    // "sourceRoot": "./@jupyterlab/hdf5/src"
   },
   "include": ["src/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,11 +2,9 @@
   "extends": "./tsconfigbase",
   "compilerOptions": {
     "inlineSources": true,
-    "lib": ["es2017", "dom"],
     "outDir": "lib",
     "rootDir": "src",
-    "sourceRoot": "./@jupyterlab/hdf5/src",
-    "types": ["node"]
+    "sourceRoot": "./@jupyterlab/hdf5/src"
   },
   "include": ["src/**/*"]
 }

--- a/tsconfigbase.json
+++ b/tsconfigbase.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://json.schemastore.org/tsconfig",
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
     "composite": true,
@@ -14,6 +15,7 @@
     "preserveWatchOutput": true,
     "resolveJsonModule": true,
     "sourceMap": true,
+    // "strictNullChecks": true,
     "target": "es2017",
     "types": []
   }


### PR DESCRIPTION
Fixes #4, #18, #22, #37

Adds support for datasets with `ndim >2` (issue #4) as well as datasets with `ndim<=1` (issue #18). The slice input box will now accept the complete subset of numpy indices that are some combination of integer indexes and slices. Though for practical purposes of display, the number of slices in the supplied index has to be between 0-2.

The PR is now mostly done. Still needs a couple of things:

- [x] 0D support, for the case of a single scalar value returned by an index without slices
- [x] 0D support, for the case of data with an empty shape
- [x] 1D support
- [ ] Some kind of UI element that displays the original shape of the currently open dataset
- [ ] Possibly also a UI element that displays the current visible shape of the currently open dataset
- [ ] Better error handling/validation w.r.t. user input of the index string

This PR should also fix the bugs reported in #22 and #37, due to the complete overhaul of how data and metadata is handled, and also thanks to @JonjonHays handy json fix.