### PR TITLE
Improve implementation of recently added n-dimensional support

### DIFF
--- a/jupyterlab_hdf/__init__.py
+++ b/jupyterlab_hdf/__init__.py
@@ -7,8 +7,10 @@ from ._version import __version__
 
 from notebook.utils import url_path_join
 
+from .attrs import HdfAttrsHandler
 from .contents import HdfContentsHandler
 from .data import HdfDataHandler
+from .meta import HdfMetaHandler
 from .snippet import HdfSnippetHandler
 
 path_regex = r'(?P<path>(?:(?:/[^/]+)+|/?))'
@@ -22,14 +24,17 @@ def _load_handlers(notebook_dir, web_app):
     # Prepend the base_url so that it works in a jupyterhub setting
     base_url = web_app.settings['base_url'] if 'base_url' in web_app.settings else '/'
 
-    contents = url_path_join(base_url, 'hdf/contents')
-    data = url_path_join(base_url, 'hdf/data')
-    snippet = url_path_join(base_url, 'hdf/snippet')
+    _handlerDict = dict((
+        ('attrs', HdfAttrsHandler),
+        ('contents', HdfContentsHandler),
+        ('data', HdfDataHandler),
+        ('meta', HdfMetaHandler),
+        ('snippet', HdfSnippetHandler),
+    ))
 
     handlers = [
-        (contents + '/(.*)', HdfContentsHandler, {'notebook_dir': notebook_dir}),
-        (data + '/(.*)', HdfDataHandler, {'notebook_dir': notebook_dir}),
-        (snippet + '/(.*)', HdfSnippetHandler, {'notebook_dir': notebook_dir}),
+        (url_path_join(base_url, 'hdf', ep, '(.*)'), handler, {'notebook_dir': notebook_dir})
+        for ep,handler in _handlerDict.items()
     ]
 
     web_app.add_handlers('.*$', handlers)

--- a/jupyterlab_hdf/attrs.py
+++ b/jupyterlab_hdf/attrs.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import h5py
+
+from .baseHandler import HdfFileManager, HdfBaseHandler
+from .util import hobjAttrsDict, jsonize
+
+__all__ = ['HdfAttrsManager', 'HdfAttrsHandler']
+
+## manager
+class HdfAttrsManager(HdfFileManager):
+    """Implements HDF5 attributes handling
+    """
+    def _getFromFile(self, f, uri, **kwargs):
+        return jsonize(hobjAttrsDict(f[uri]))
+
+## handler
+class HdfAttrsHandler(HdfBaseHandler):
+    """A handler for HDF5 attributes
+    """
+    managerClass = HdfAttrsManager

--- a/jupyterlab_hdf/baseHandler.py
+++ b/jupyterlab_hdf/baseHandler.py
@@ -112,9 +112,15 @@ class HdfBaseHandler(APIHandler):
         """
         uri = '/' + self.get_query_argument('uri').lstrip('/')
 
-        _kws = ('atleast_2d', 'ixstr', 'subixstr')
+        # get any query parameter vals
+        _kws = ('min_ndim', 'ixstr', 'subixstr')
         _vals = (self.get_query_argument(kw, default=None) for kw in _kws)
-        kwargs = {kw:(val if val else None) for kw,val in zip(_kws, _vals)}
+        kwargs = {k:v if v else None for k,v in zip(_kws, _vals)}
+
+        # do any needed type conversions of param vals
+        _num_kws = ('min_ndim', )
+        for k in (k for k in _num_kws if kwargs[k] is not None):
+            kwargs[k] = int(kwargs[k])
 
         try:
             self.finish(simplejson.dumps(self.manager.get(path, uri, **kwargs), ignore_nan=True))

--- a/jupyterlab_hdf/contents.py
+++ b/jupyterlab_hdf/contents.py
@@ -14,16 +14,27 @@ __all__ = ['HdfContentsManager', 'HdfContentsHandler']
 class HdfContentsManager(HdfFileManager):
     """Implements HDF5 contents handling
     """
-    def _getFromFile(self, f, uri, **kwargs):
+    def _getFromFile(self, f, uri, ixstr=None, min_ndim=None, **kwargs):
         hobj = f[uri]
 
         if isinstance(hobj, h5py.Group):
             # recurse one level
             return [
-                jsonize(hobjContentsDict(subhobj, uri=uriJoin(uri, subhobj.name))) for subhobj in hobj.values()
+                jsonize(hobjContentsDict(
+                    subhobj,
+                    content=False,
+                    ixstr=ixstr,
+                    min_ndim=min_ndim,
+                ))
+                for subhobj in hobj.values()
             ]
         else:
-            return hobjContentsDict(hobj, uri=uri)
+            return jsonize(hobjContentsDict(
+                hobj,
+                content=True,
+                ixstr=ixstr,
+                min_ndim=min_ndim,
+            ))
 
 ## handler
 class HdfContentsHandler(HdfBaseHandler):

--- a/jupyterlab_hdf/contents.py
+++ b/jupyterlab_hdf/contents.py
@@ -6,7 +6,7 @@
 import h5py
 
 from .baseHandler import HdfFileManager, HdfBaseHandler
-from .util import dsetContentDict, dsetDict, groupDict, jsonize, uriJoin, uriName
+from .util import dsetContentDict, groupContentDict, jsonize, uriJoin, uriName
 
 __all__ = ['HdfContentsManager', 'HdfContentsHandler']
 
@@ -14,19 +14,26 @@ __all__ = ['HdfContentsManager', 'HdfContentsHandler']
 class HdfContentsManager(HdfFileManager):
     """Implements HDF5 contents handling
     """
-    def _getFromFile(self, f, uri, ixstr, **kwargs):
+    def _getFromFile(self, f, uri, ixstr=None, min_ndim=None, **kwargs):
         obj = f[uri]
 
         if isinstance(obj, h5py.Group):
-            return [(groupDict if isinstance(val, h5py.Group) else dsetDict)
-                        (name=name, uri=uriJoin(uri, name))
-                    for name,val in obj.items()]
+            return [
+                dict((
+                    ('content', jsonize(groupContentDict(subobj)) if isinstance(subobj, h5py.Group) else None),
+                    ('name', name),
+                    ('type', 'group' if isinstance(subobj, h5py.Group) else 'dataset'),
+                    ('uri', uriJoin(uri, name)),
+                ))
+                for name,subobj in obj.items()
+            ]
         elif isinstance(obj, h5py.Dataset):
-            return dsetDict(
-                name=uriName(uri),
-                uri=uri,
-                content=jsonize(dsetContentDict(obj, ixstr)),
-            )
+            return dict((
+                ('content', jsonize(dsetContentDict(obj, ixstr=ixstr, min_ndim=min_ndim))),
+                ('name', uriName(uri)),
+                ('type', 'dataset'),
+                ('uri', uri),
+            ))
         else:
             raise ValueError("unknown h5py obj: %s" % obj)
 

--- a/jupyterlab_hdf/data.py
+++ b/jupyterlab_hdf/data.py
@@ -13,7 +13,7 @@ __all__ = ['HdfDataManager', 'HdfDataHandler']
 class HdfDataManager(HdfFileManager):
     """Implements HDF5 data handling
     """
-    def _getFromFile(self, f, uri, ixstr, subixstr=None, atleast_2d=False, **kwargs):
+    def _getFromFile(self, f, uri, ixstr, subixstr=None, min_ndim=None, **kwargs):
         # # DEBUG: uncomment for logging
         # from .util import dsetContentDict, parseSubindex
         # logd = dsetContentDict(f[uri], ixstr=ixstr)
@@ -22,7 +22,7 @@ class HdfDataManager(HdfFileManager):
         #     logd['ixcompound'] = parseSubindex(ixstr, subixstr, f[uri].shape)
         # self.log.info('{}'.format(logd))
 
-        return dsetChunk(f[uri], ixstr, subixstr=subixstr, atleast_2d=atleast_2d).tolist()
+        return dsetChunk(f[uri], ixstr, subixstr=subixstr, min_ndim=min_ndim).tolist()
 
 
 ## handler

--- a/jupyterlab_hdf/meta.py
+++ b/jupyterlab_hdf/meta.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import h5py
+
+from .baseHandler import HdfFileManager, HdfBaseHandler
+from .util import hobjMetaDict, jsonize
+
+__all__ = ['HdfMetaManager', 'HdfMetaHandler']
+
+## manager
+class HdfMetaManager(HdfFileManager):
+    """Implements HDF5 metadata handling
+    """
+    def _getFromFile(self, f, uri, ixstr=None, min_ndim=None, **kwargs):
+        return jsonize(hobjMetaDict(f[uri], ixstr=ixstr, min_ndim=min_ndim))
+
+## handler
+class HdfMetaHandler(HdfBaseHandler):
+    """A handler for HDF5 metadata
+    """
+    managerClass = HdfMetaManager

--- a/jupyterlab_hdf/util.py
+++ b/jupyterlab_hdf/util.py
@@ -71,20 +71,21 @@ def hobjAttrsDict(hobj):
         *_hobjDict(hobj).items(),
     ))
 
-def hobjContentsDict(hobj, uri):
+def hobjContentsDict(hobj, content=False, ixstr=None, min_ndim=None):
     return dict((
+        ('content', hobjMetaDict(hobj, ixstr=ixstr, min_ndim=min_ndim) if content else None),
         *_hobjDict(hobj).items(),
-        ('uri', uri),
+        ('uri', hobj.name),
     ))
 
 def hobjMetaDict(hobj, ixstr=None, min_ndim=None):
     d = _hobjDict(hobj)
 
     if d['type'] == 'dataset':
-        return dict(sorted(
+        return dict(sorted((
             *d.items(),
             *_dsetMetaDict(hobj, ixstr=ixstr, min_ndim=min_ndim).items(),
-        ))
+        )))
     else:
         return d
 
@@ -98,14 +99,14 @@ def _dsetMetaDict(dset, ixstr=None, min_ndim=None):
     ))
 
 def _hobjDict(hobj):
-    if isinstance(hobj, h5py.dataset):
+    if isinstance(hobj, h5py.Dataset):
         tipe = 'dataset'
     else:
         # for now, treat links and such as groups
         tipe = 'group'
 
     return dict((
-        ('name', hobj.name),
+        ('name', uriName(hobj.name)),
         ('type', tipe),
     ))
 

--- a/scratch/nested-dataset.ipynb
+++ b/scratch/nested-dataset.ipynb
@@ -94,6 +94,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# genNested('nested_int_one_d', N=2, fillRange=True, shape=(1000,)*1)\n",
+    "genNested('nested_int_high_d', N=2, fillRange=True, shape=(40, 50, 60, 70))"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -11,8 +11,9 @@ import { Contents, ServerConnection } from "@jupyterlab/services";
 
 import {
   hdfContentsRequest,
-  HdfContents,
+  HdfDatasetContents,
   HdfDirectoryListing,
+  HdfGroupContents,
   parseHdfQuery
 } from "./hdf";
 
@@ -291,7 +292,7 @@ namespace Private {
    */
   export function hdfContentsToJupyterContents(
     path: string,
-    contents: HdfContents | HdfDirectoryListing
+    contents: (HdfDatasetContents | HdfGroupContents) | HdfDirectoryListing
   ): Contents.IModel {
     if (Array.isArray(contents)) {
       // If we have an array, it is a directory of HdfContents.
@@ -338,7 +339,9 @@ namespace Private {
     } else {
       throw makeError(
         500,
-        `"${contents.name}" has and unexpected type: ${contents.type}`
+        `"${(contents as any).name}" has and unexpected type: ${
+          (contents as any).type
+        }`
       );
     }
   }

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -36,13 +36,12 @@ import {
 } from "./exception";
 
 import {
-  HdfContents,
-  hdfContentsRequest,
   hdfDataRequest,
-  IContentsParameters,
   IDataParameters,
+  IMetaParameters,
   IDatasetMeta,
-  parseHdfQuery
+  parseHdfQuery,
+  hdfMetaRequest
 } from "./hdf";
 
 import { noneSlice, slice } from "./slice";
@@ -208,12 +207,12 @@ export abstract class HdfDatasetModel extends DataModel {
     }
   }
 
-  protected async getMeta(params: IContentsParameters): Promise<IDatasetMeta> {
+  protected async getMeta(params: IMetaParameters): Promise<IDatasetMeta> {
     try {
-      return ((await hdfContentsRequest(
+      return (await hdfMetaRequest(
         params,
         this._serverSettings
-      )) as HdfContents).content as IDatasetMeta;
+      )) as IDatasetMeta;
     } catch (err) {
       if (err instanceof HdfResponseError) {
         modalHdfError(err);
@@ -255,8 +254,6 @@ export abstract class HdfDatasetModel extends DataModel {
       ixstr: this._ixstr,
       min_ndim: 2,
       subixstr
-      // skip subixstr in the 0d case
-      // ...(subixstr ? {subixstr: subixstr} : {}),
     };
 
     const data = await this.getData(params);
@@ -411,7 +408,7 @@ class HdfDatasetModelFromContext extends HdfDatasetModel {
  * Subclass that constructs a dataset model from simple parameters
  */
 export class HdfDatasetModelFromPath extends HdfDatasetModel {
-  constructor(params: IContentsParameters) {
+  constructor(params: IMetaParameters) {
     super();
 
     this.getMeta(params).then(meta => {
@@ -423,7 +420,7 @@ export class HdfDatasetModelFromPath extends HdfDatasetModel {
    * Handle actions that should be taken when the model is ready.
    */
   private _onMetaReady(
-    { fpath, uri }: IContentsParameters,
+    { fpath, uri }: IMetaParameters,
     meta: IDatasetMeta
   ): void {
     this.init({ fpath, uri, meta });

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -130,35 +130,8 @@ export class HdfDatasetModelBase extends DataModel {
     this.refresh();
   }
 
-  set meta(meta: IDatasetMeta) {
-    this._meta = meta;
-
-    // all reasoning about 0d vs 1d vs nd goes here
-    if (this._meta.visshape.length < 1) {
-      // for 0d (scalar), use (1, 1)
-      this._hassubix = [false, false];
-      this._n = [1, 1];
-      this._nheader = [0, 0];
-      this._slice = [slice(0, 1), slice(0, 1)];
-    } else if (this._meta.vissize <= 0) {
-      // for 0d (empty), use (0, 0)
-      this._hassubix = [false, false];
-      this._n = [0, 0];
-      this._nheader = [0, 0];
-      this._slice = [noneSlice(), noneSlice()];
-    } else if (this._meta.visshape.length < 2) {
-      // for 1d, use (1, size)
-      this._hassubix = [false, true];
-      this._n = [1, this._meta.vissize];
-      this._nheader = [1, 0];
-      this._slice = [slice(0, 1), this._meta.vislabels[0]];
-    } else {
-      // for 2d up, use standard shape
-      this._hassubix = [true, true];
-      this._n = this._meta.visshape;
-      this._nheader = [1, 1];
-      this._slice = this._meta.vislabels;
-    }
+  get meta(): IDatasetMeta {
+    return this._meta;
   }
 
   /**
@@ -173,7 +146,7 @@ export class HdfDatasetModelBase extends DataModel {
     const oldColCount = this.columnCount("body");
 
     // changing the meta will also change the result of the row/colCount methods
-    this.meta = meta;
+    this._setMeta(meta);
 
     this._blocks = Object();
 
@@ -311,18 +284,49 @@ export class HdfDatasetModelBase extends DataModel {
     );
   };
 
-  protected _serverSettings: ServerConnection.ISettings = ServerConnection.makeSettings();
+  private _setMeta(meta: IDatasetMeta) {
+    this._meta = meta;
+
+    // all reasoning about 0d vs 1d vs nd goes here
+    if (this._meta.visshape.length < 1) {
+      // for 0d (scalar), use (1, 1)
+      this._hassubix = [false, false];
+      this._n = [1, 1];
+      this._nheader = [0, 0];
+      this._slice = [slice(0, 1), slice(0, 1)];
+    } else if (this._meta.vissize <= 0) {
+      // for 0d (empty), use (0, 0)
+      this._hassubix = [false, false];
+      this._n = [0, 0];
+      this._nheader = [0, 0];
+      this._slice = [noneSlice(), noneSlice()];
+    } else if (this._meta.visshape.length < 2) {
+      // for 1d, use (1, size)
+      this._hassubix = [false, true];
+      this._n = [1, this._meta.vissize];
+      this._nheader = [1, 0];
+      this._slice = [slice(0, 1), this._meta.vislabels[0]];
+    } else {
+      // for 2d up, use standard shape
+      this._hassubix = [true, true];
+      this._n = this._meta.visshape;
+      this._nheader = [1, 1];
+      this._slice = this._meta.vislabels;
+    }
+  }
 
   protected _fpath: string = "";
   protected _uri: string = "";
-  protected _meta: IDatasetMeta;
 
-  protected _ixstr: string = "";
+  protected _serverSettings: ServerConnection.ISettings = ServerConnection.makeSettings();
 
   protected _hassubix = [false, false];
   protected _n = [0, 0];
   protected _nheader = [0, 0];
   protected _slice = [noneSlice(), noneSlice()];
+
+  private _meta: IDatasetMeta;
+  private _ixstr: string = "";
 
   private _blocks: any = Object();
   private _blockSize: number = 100;

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -90,7 +90,7 @@ export abstract class HdfDatasetModel extends DataModel {
       );
     }
 
-    // derive metadata for the default ixstr from the metadata for no ixstr
+    // derive metadata for the default ixstr (eg ':, :, ...') from the metadata for no ixstr (eg '...')
     const metaIx: IDatasetMeta = {
       ...meta,
       labels: meta.labels.slice(-2),
@@ -213,7 +213,7 @@ export abstract class HdfDatasetModel extends DataModel {
       return ((await hdfContentsRequest(
         params,
         this._serverSettings
-      )) as HdfContents).content;
+      )) as HdfContents).content as IDatasetMeta;
     } catch (err) {
       if (err instanceof HdfResponseError) {
         modalHdfError(err);
@@ -252,8 +252,8 @@ export abstract class HdfDatasetModel extends DataModel {
     const params = {
       fpath: this._fpath,
       uri: this._uri,
-      atleast_2d: true,
       ixstr: this._ixstr,
+      min_ndim: 2,
       subixstr
       // skip subixstr in the 0d case
       // ...(subixstr ? {subixstr: subixstr} : {}),

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -64,27 +64,38 @@ export abstract class HdfDatasetModel extends DataModel {
   init({
     fpath,
     uri,
-    ixstr,
     meta
-  }: IContentsParameters & { meta: IDatasetMeta }): void {
+  }: {
+    fpath: string;
+    uri: string;
+    meta: IDatasetMeta;
+  }): void {
     this._fpath = fpath;
     this._uri = uri;
     this._meta = meta;
 
-    if (!ixstr && ixstr !== "") {
-      if (this._meta.ndim < 1) {
-        ixstr = "";
-      } else if (this._meta.ndim < 2) {
-        ixstr = ":";
-      } else {
-        ixstr = [...Array(this._meta.ndim - 2).fill("0"), ":", ":"].join(", ");
-      }
+    if (this._meta.ndim < 1) {
+      this._ixstr = "";
+    } else if (this._meta.ndim < 2) {
+      this._ixstr = ":";
+    } else {
+      this._ixstr = [...Array(this._meta.ndim - 2).fill("0"), ":", ":"].join(
+        ", "
+      );
     }
 
-    this._ixstr = ixstr;
+    const metaIx: IDatasetMeta = {
+      ...meta,
+      labels: meta.labels.slice(-2),
+      ndim: Math.max(meta.ndim, 2),
+      shape: meta.shape.slice(-2),
+      size: meta.shape.length
+        ? meta.shape.slice(-2).reduce((x, y) => x * y)
+        : meta.size
+    };
 
     // Refresh wrt the newly set ix and then resolve the ready promise.
-    this._refresh(meta).then(() => {
+    this._refresh(metaIx).then(() => {
       this._ready.resolve(undefined);
     });
   }

--- a/src/exception.tsx
+++ b/src/exception.tsx
@@ -52,3 +52,26 @@ export function modalHdfError(
     buttons: buttons
   });
 }
+
+export function modalResponseError(
+  error: ServerConnection.ResponseError,
+  buttons: ReadonlyArray<Dialog.IButton> = [
+    Dialog.okButton({ label: "Dismiss" })
+  ]
+) {
+  const { message, traceback } = error;
+  console.warn({ message, traceback });
+
+  return showDialog({
+    title: "jupyterlab-hdf error",
+    body: (
+      <div className={HDF_MODAL_TEXT_CLASS}>
+        <div>message</div>
+        <div>{message}</div>
+        <div>traceback</div>
+        <div>{traceback}</div>
+      </div>
+    ),
+    buttons: buttons
+  });
+}

--- a/src/hdf.ts
+++ b/src/hdf.ts
@@ -230,15 +230,13 @@ export interface IDatasetMeta {
 
   dtype: string;
 
+  labels: ISlice[];
+
+  ndim: number;
+
   shape: number[];
 
-  ixstr: string;
-
-  vislabels: ISlice[];
-
-  visshape: number[];
-
-  vissize: number;
+  size: number;
 }
 
 /**

--- a/src/hdf.ts
+++ b/src/hdf.ts
@@ -69,11 +69,11 @@ export function hdfContentsRequest(
   settings: ServerConnection.ISettings
 ): Promise<HdfDirectoryListing | HdfContents> {
   // allow the query parameters to be optional
-  const { fpath, uri, ixstr } = parameters;
+  const { fpath, uri, ixstr, min_ndim } = parameters;
 
   const fullUrl =
     URLExt.join(settings.baseUrl, "hdf", "contents", fpath).split("?")[0] +
-    objectToQueryString({ uri, ixstr });
+    objectToQueryString({ uri, ixstr, min_ndim });
 
   return hdfApiRequest(fullUrl, {}, settings);
 }
@@ -87,11 +87,11 @@ export function hdfDataRequest(
   settings: ServerConnection.ISettings
 ): Promise<number[][]> {
   // require the uri, row, and col query parameters
-  const { fpath, uri, ixstr, atleast_2d, subixstr } = parameters;
+  const { fpath, uri, ixstr, min_ndim, subixstr } = parameters;
 
   const fullUrl =
     URLExt.join(settings.baseUrl, "hdf", "data", fpath).split("?")[0] +
-    objectToQueryString({ uri, ixstr, atleast_2d, subixstr });
+    objectToQueryString({ uri, ixstr, min_ndim, subixstr });
 
   return hdfApiRequest(fullUrl, {}, settings);
 }
@@ -153,17 +153,17 @@ export interface IContentsParameters {
    */
   fpath: string;
 
+  ixstr?: string;
+
+  min_ndim?: number;
+
   /**
    * Path within an HDF5 file to a specific group or dataset.
    */
   uri: string;
-
-  ixstr?: string;
 }
 
 export interface IDataParameters extends IContentsParameters {
-  atleast_2d?: boolean;
-
   subixstr?: string;
 }
 
@@ -189,7 +189,13 @@ export class HdfContents {
   /**
    * If object is a dataset, all of its metadata encoded as a JSON string.
    */
-  content?: IDatasetMeta;
+  content?: IDatasetMeta | IGroupMeta;
+}
+
+export interface IGroupMeta {
+  attrs: { [key: string]: any };
+
+  name: string;
 }
 
 export interface IDatasetMeta {
@@ -197,6 +203,20 @@ export interface IDatasetMeta {
 
   dtype: string;
 
+  name: string;
+
+  // shapemeta: IDatasetShapeMeta;
+
+  labels: ISlice[];
+
+  ndim: number;
+
+  shape: number[];
+
+  size: number;
+}
+
+export interface IDatasetShapeMeta {
   labels: ISlice[];
 
   ndim: number;

--- a/src/hdf.ts
+++ b/src/hdf.ts
@@ -20,7 +20,7 @@ export const HDF_DATASET_MIME_TYPE = `${HDF_MIME_TYPE}.dataset`;
  */
 function filterNull<T>(obj: T): Partial<T> {
   return (Object.entries(obj) as [keyof T, any]).reduce(
-    (a, [k, v]) => (v ? ((a[k] = v), a) : a),
+    (a, [k, v]) => (v != null ? ((a[k] = v), a) : a),
     {}
   );
 }
@@ -83,7 +83,7 @@ export function hdfAttrsRequest(
 export function hdfContentsRequest(
   parameters: IContentsParameters,
   settings: ServerConnection.ISettings
-): Promise<HdfDirectoryListing | HdfContents> {
+): Promise<(HdfDatasetContents | HdfGroupContents) | HdfDirectoryListing> {
   // allow the query parameters to be optional
   const { fpath, uri } = parameters;
 
@@ -229,7 +229,7 @@ export interface IMetaParameters extends IParameters {
 /**
  * typings representing contents from an object in an hdf5 file
  */
-export class HdfContents {
+class HdfContents {
   /**
    * The name of the object.
    */
@@ -245,6 +245,23 @@ export class HdfContents {
    */
   uri: string;
 }
+
+export class HdfDatasetContents extends HdfContents {
+  content: IDatasetMeta;
+
+  type: "dataset";
+}
+
+export class HdfGroupContents extends HdfContents {
+  content: IGroupMeta;
+
+  type: "group";
+}
+
+/**
+ * Typings representing directory contents
+ */
+export type HdfDirectoryListing = (HdfDatasetContents | HdfGroupContents)[];
 
 interface IAttrs {
   attrs: { [key: string]: any };
@@ -285,11 +302,6 @@ export interface IDatasetMeta extends IMeta {
 export interface IGroupMeta extends IMeta {
   type: "group";
 }
-
-/**
- * Typings representing directory contents
- */
-export type HdfDirectoryListing = HdfContents[];
 
 // /**
 //  * Typings representing a directory from the Hdf

--- a/src/toolbar.tsx
+++ b/src/toolbar.tsx
@@ -9,7 +9,7 @@ import { ReactWidget } from "@jupyterlab/apputils";
 
 import * as React from "react";
 
-import { HdfDatasetModelBase } from "./dataset";
+import { HdfDatasetModel } from "./dataset";
 
 const TOOLBAR_IX_INPUT_CLASS = ".jp-IxInputToolbar";
 const TOOLBAR_IX_INPUT_BOX_CLASS = ".jp-IxInputToolbar-box";
@@ -65,7 +65,7 @@ export class IxInput extends ReactWidget {
     this.addClass(TOOLBAR_IX_INPUT_CLASS);
 
     this._grid = widget;
-    this._model = this._grid.dataModel as HdfDatasetModelBase;
+    this._model = this._grid.dataModel as HdfDatasetModel;
   }
 
   render() {
@@ -79,7 +79,7 @@ export class IxInput extends ReactWidget {
   }
 
   private _grid: DataGrid;
-  private _model: HdfDatasetModelBase;
+  private _model: HdfDatasetModel;
 }
 
 export class IxInputBox extends React.Component<


### PR DESCRIPTION
Support for datasets of all dimensional from 0D to 32D was recently added in #41. It works well, but the implementation is still a bit rough. This PR aims to clean up the implementation, with a particular eye towards simplifying and rationalizing the API.

- [x] remove display-oriented logic from backend
- [x] return minimal set of shape-related data from backend
- [x] add `min_dims` query parameter to relevant backends
- [x] split out new `hdf/attrs` and `hdf/meta` backends out
- [x] fix any obvious bugs the above changes cause