### PR TITLE
api docs: add list of `required` props to object shemas

### DIFF
--- a/jupyterlab_hdf/api/api.yaml
+++ b/jupyterlab_hdf/api/api.yaml
@@ -202,6 +202,7 @@ components:
       additionalProperties: true
     contents:
       description: "data representing an arbitrary hdf object, in the format required by the jupyterlab `Contents` stack"
+      required: [name, type, uri]
       type: object
       properties:
         content:
@@ -224,6 +225,7 @@ components:
           type: number
     dataset_meta:
       description: "metadata of an hdf dataset, as a dictionary"
+      required: [dtype, labels, name, ndim, shape, size, type]
       type: object
       properties:
         dtype:
@@ -254,6 +256,7 @@ components:
           type: string
     group_meta:
       description: "metadata of an hdf group, as a dictionary"
+      required: [name, type]
       type: object
       properties:
         name:
@@ -278,6 +281,7 @@ components:
       type: string
     slice:
       description: "python-style slice"
+      required: [start, stop, step]
       type: object
       properties:
         start:


### PR DESCRIPTION
this fix clarifies which properties are required in the object definitions in the `schemas` section of the api docs