### PR TITLE
Fix api typos

### DIFF
--- a/jupyterlab_hdf/api/api.yaml
+++ b/jupyterlab_hdf/api/api.yaml
@@ -15,7 +15,6 @@ paths:
     parameters:
       - $ref: "#/components/parameters/fpath"
       - $ref: "#/components/parameters/uri"
-
     get:
       description: "get the attributes of an hdf object"
       summary: "get the attributes of an hdf object"
@@ -37,7 +36,6 @@ paths:
       - $ref: "#/components/parameters/uri"
       - $ref: "#/components/parameters/ixstr"
       - $ref: "#/components/parameters/min_ndim"
-
     get:
       description: "get the contents of an hdf object"
       summary: "get the contents of an hdf object"
@@ -60,7 +58,6 @@ paths:
       - $ref: "#/components/parameters/ixstr"
       - $ref: "#/components/parameters/subixstr"
       - $ref: "#/components/parameters/min_ndim"
-
     get:
       description: "get raw array data from one hdf dataset, as a json blob"
       summary: "get data from an hdf dataset"
@@ -82,7 +79,6 @@ paths:
       - $ref: "#/components/parameters/uri"
       - $ref: "#/components/parameters/ixstr"
       - $ref: "#/components/parameters/min_ndim"
-
     get:
       description: "get the metadata of an hdf object. If the object is a dataset and the ixstr parameter is provided, all shape-related metadata will be for the slab specified by ixstr"
       summary: "get the metadata of an hdf object"
@@ -98,10 +94,12 @@ paths:
         "500":
           $ref: "#/components/responses/500"
 
-  /hdf/snippet/{fpath}{?uri}:
+  /hdf/snippet/{fpath}{?uri}{?ixstr}{?subixstr}:
     parameters:
       - $ref: "#/components/parameters/fpath"
       - $ref: "#/components/parameters/uri"
+      - $ref: "#/components/parameters/ixstr"
+      - $ref: "#/components/parameters/subixstr"
     get:
       description: "get a Python snippet that fetches the hdf dataset or group pointed to by the path and uri"
       summary: "get a Python snippet that fetches an hdf dataset or group"
@@ -192,6 +190,14 @@ components:
         "name": "beta",
         "type": "group"
       }
+    dataset_py_snippet:
+      description: "python snippet for dataset"
+      value:
+        "with h5py.File('/Users/alice/git/jupyterlab-hdf/example/nested_int.hdf5', 'r') as f:\n    data = f['/leaf01/data01']"
+    group_py_snippet:
+      description: "python snippet for group"
+      value:
+        "with h5py.File('/Users/alice/git/jupyterlab-hdf/example/nested_int.hdf5', 'r') as f:\n    group = f['/leaf01']"
 
   parameters:
     fpath:
@@ -293,6 +299,11 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/py_snippet"
+          examples:
+            "python snippet for dataset":
+              $ref: "#/components/examples/dataset_py_snippet"
+            "python snippet for group":
+              $ref: "#/components/examples/group_py_snippet"
 
   schemas:
     attrs:

--- a/jupyterlab_hdf/api/api.yaml
+++ b/jupyterlab_hdf/api/api.yaml
@@ -119,6 +119,85 @@ paths:
 
 
 components:
+  examples:
+    dataset_contents:
+      description: "example contents of a dataset object"
+      value: {
+        "content": {
+          "dtype": "int64",
+          "labels": [
+            {"start": 2, "stop": 11, "step": 1},
+            {"start": 3, "stop": 4, "step": 1},
+            {"start": 1, "stop": 16, "step": 1},
+          ],
+          "name": "foo",
+          "ndim": 2,
+          "shape": [9, 15],
+          "size": 135,
+          "type": "dataset"
+        },
+        "name": "foo",
+        "type": "dataset",
+        "uri": "able/foo"
+      }
+    group_contents:
+      description: "example contents of a group object"
+      value: [
+        {"name": "baker", "type": "group", "uri": "able/baker"},
+        {"name": "foo", "type": "dataset", "uri": "able/foo"},
+        {"name": "bar", "type": "dataset", "uri": "able/bar"}
+      ]
+    data_1d:
+      description: "a 1D chunk of raw array data"
+      value: [11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26]
+    data_2d:
+      description: "a 2D chunk of raw array data"
+      value: [[11, 12, 13, 14], [15, 16, 17, 18], [19, 20, 21, 22], [23, 24, 25, 26]]
+    data_4d:
+      description: "a 4D chunk of raw array data"
+      value: [[[[11, 12], [13, 14]], [[15, 16], [17, 18]]], [[[19, 20], [21, 22]], [[23, 24], [25, 26]]]]
+    dataset_meta:
+      description: "metadata for dataset of shape `[13, 5, 17]`"
+      value: {
+        "content": {
+          "dtype": "int64",
+          "labels": [
+            {"start": 2, "stop": 11, "step": 1},
+            {"start": 3, "stop": 4, "step": 1},
+            {"start": 1, "stop": 16, "step": 1},
+          ],
+          "name": "foo",
+          "ndim": 2,
+          "shape": [9, 15],
+          "size": 135,
+          "type": "dataset"
+        },
+        "name": "foo",
+        "type": "dataset",
+        "uri": "able/foo"
+      }
+    dataset_meta_w_ixstr:
+      description: 'metadata for dataset of shape `[13, 5, 17]`, given an ixstr of `"2:11, 3, 1:16"`'
+      value: {
+        "dtype": "int64",
+        "labels": [
+          {"start": 2, "stop": 11, "step": 1},
+          {"start": 3, "stop": 4, "step": 1},
+          {"start": 1, "stop": 16, "step": 1},
+        ],
+        "name": "foo",
+        "ndim": 2,
+        "shape": [9, 15],
+        "size": 135,
+        "type": "dataset"
+      }
+    group_meta:
+      description: "metadata for group"
+      value: {
+        "name": "beta",
+        "type": "group"
+      }
+
   parameters:
     fpath:
       name: fpath
@@ -159,7 +238,7 @@ components:
 
   responses:
     "400":
-      description: "the request was malformed; url should be of the format 'fpath?uri=uri'"
+      description: 'the request was malformed; url should be of the format `"fpath?uri=uri"`'
     "401":
       description: "the request did not specify a file that `h5py` could understand"
     "403":
@@ -173,7 +252,7 @@ components:
           schema:
             $ref: "#/components/schemas/attrs"
     contents:
-      description: "data representing an arbitrary hdf object, in the format required by the jupyterlab `Contents` stack. May be either a single object or an array"
+      description: "data representing an arbitrary hdf object, in the format required by the jupyterlab `Contents` stack. If object is a dataset, basic information (including metadata) about that dataset will be reutrned as a dict. If object is a group, then basic information (but not metadata) about that group's children will be returned as an array of dicts"
       content:
         application/json:
           schema:
@@ -182,18 +261,37 @@ components:
             - type: array
               items:
                 $ref: "#/components/schemas/contents"
+          examples:
+            "contents of a dataset":
+              $ref: "#/components/examples/dataset_contents"
+            "contents of a group":
+              $ref: "#/components/examples/group_contents"
     data:
       description: "a chunk of raw array data from an hdf dataset. May be of any dimensionality"
       content:
         application/json:
           schema:
             $ref: "#/components/schemas/data"
+          examples:
+            "1D data":
+              $ref: "#/components/examples/data_1d"
+            "2D data":
+              $ref: "#/components/examples/data_2d"
+            "4D data":
+              $ref: "#/components/examples/data_4d"
     meta:
       description: "metadata of an arbitrary hdf object, as a dictionary"
       content:
         application/json:
           schema:
             $ref: "#/components/schemas/meta"
+          examples:
+            "metadata for dataset":
+              $ref: "#/components/examples/dataset_meta"
+            "metadata for dataset, given an ixstr":
+              $ref: "#/components/examples/dataset_meta_w_ixstr"
+            "metadata for group":
+              $ref: "#/components/examples/group_meta"
     py_snippet:
       description: "python code snippet"
       content:
@@ -217,7 +315,7 @@ components:
           description: "object name (ie last part of uri)"
           type: string
         type:
-          description: "the string literal 'dataset'"
+          description: 'the string literal `"dataset"`'
           enum: ["dataset"]
           type: string
         uri:
@@ -228,13 +326,11 @@ components:
       required: [name, type, uri]
       type: object
       properties:
-        content:
-          $ref: "#/components/schemas/group_meta"
         name:
           description: "object name (ie last part of uri)"
           type: string
         type:
-          description: "the string literal 'group'"
+          description: 'the string literal `"group"`'
           enum: ["group"]
           type: string
         uri:
@@ -285,7 +381,7 @@ components:
           description: "count of entries of an hdf dataset"
           type: number
         type:
-          description: "the string literal 'dataset'"
+          description: 'the string literal `"dataset"`'
           enum: ["dataset"]
           type: string
     group_meta:
@@ -297,7 +393,7 @@ components:
           description: "name of hdf group"
           type: string
         type:
-          description: "the string literal 'group'"
+          description: 'the string literal `"group"`'
           enum: ["group"]
           type: string
     meta:

--- a/jupyterlab_hdf/api/api.yaml
+++ b/jupyterlab_hdf/api/api.yaml
@@ -126,26 +126,26 @@ components:
         "content": {
           "dtype": "int64",
           "labels": [
-            {"start": 2, "stop": 11, "step": 1},
-            {"start": 3, "stop": 4, "step": 1},
-            {"start": 1, "stop": 16, "step": 1},
+            {"start": 0, "stop": 13, "step": 1},
+            {"start": 0, "stop": 5, "step": 1},
+            {"start": 0, "stop": 17, "step": 1},
           ],
           "name": "foo",
-          "ndim": 2,
-          "shape": [9, 15],
-          "size": 135,
+          "ndim": 3,
+          "shape": [13, 5, 17],
+          "size": 1105,
           "type": "dataset"
         },
         "name": "foo",
         "type": "dataset",
-        "uri": "able/foo"
+        "uri": "/able/foo"
       }
     group_contents:
       description: "example contents of a group object"
       value: [
-        {"name": "baker", "type": "group", "uri": "able/baker"},
-        {"name": "foo", "type": "dataset", "uri": "able/foo"},
-        {"name": "bar", "type": "dataset", "uri": "able/bar"}
+        {"name": "baker", "type": "group", "uri": "/able/baker"},
+        {"name": "foo", "type": "dataset", "uri": "/able/foo"},
+        {"name": "bar", "type": "dataset", "uri": "/able/bar"}
       ]
     data_1d:
       description: "a 1D chunk of raw array data"
@@ -159,22 +159,17 @@ components:
     dataset_meta:
       description: "metadata for dataset of shape `[13, 5, 17]`"
       value: {
-        "content": {
-          "dtype": "int64",
-          "labels": [
-            {"start": 2, "stop": 11, "step": 1},
-            {"start": 3, "stop": 4, "step": 1},
-            {"start": 1, "stop": 16, "step": 1},
-          ],
-          "name": "foo",
-          "ndim": 2,
-          "shape": [9, 15],
-          "size": 135,
-          "type": "dataset"
-        },
+        "dtype": "int64",
+        "labels": [
+          {"start": 0, "stop": 13, "step": 1},
+          {"start": 0, "stop": 5, "step": 1},
+          {"start": 0, "stop": 17, "step": 1},
+        ],
         "name": "foo",
-        "type": "dataset",
-        "uri": "able/foo"
+        "ndim": 3,
+        "shape": [13, 5, 17],
+        "size": 1105,
+        "type": "dataset"
       }
     dataset_meta_w_ixstr:
       description: 'metadata for dataset of shape `[13, 5, 17]`, given an ixstr of `"2:11, 3, 1:16"`'

--- a/jupyterlab_hdf/attrs.py
+++ b/jupyterlab_hdf/attrs.py
@@ -3,8 +3,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-import h5py
-
 from .baseHandler import HdfFileManager, HdfBaseHandler
 from .util import hobjAttrsDict, jsonize
 

--- a/jupyterlab_hdf/data.py
+++ b/jupyterlab_hdf/data.py
@@ -8,7 +8,6 @@ from .util import dsetChunk, jsonize
 
 __all__ = ['HdfDataManager', 'HdfDataHandler']
 
-
 ## manager
 class HdfDataManager(HdfFileManager):
     """Implements HDF5 data handling
@@ -23,7 +22,6 @@ class HdfDataManager(HdfFileManager):
         # self.log.info('{}'.format(logd))
 
         return jsonize(dsetChunk(f[uri], ixstr=ixstr, subixstr=subixstr, min_ndim=min_ndim))
-
 
 ## handler
 class HdfDataHandler(HdfBaseHandler):

--- a/jupyterlab_hdf/meta.py
+++ b/jupyterlab_hdf/meta.py
@@ -3,8 +3,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-import h5py
-
 from .baseHandler import HdfFileManager, HdfBaseHandler
 from .util import hobjMetaDict, jsonize
 

--- a/jupyterlab_hdf/snippet.py
+++ b/jupyterlab_hdf/snippet.py
@@ -6,21 +6,37 @@
 import h5py
 
 from .baseHandler import HdfBaseManager, HdfBaseHandler
+from .util import hobjType
 
 __all__ = ['HdfSnippetManager', 'HdfSnippetHandler']
 
 ## snippet templates
-dsetTemp = '''with h5py.File('{fpath}', 'r') as f:
-    data = f['{uri}']'''
+dsetTemplate = '''with h5py.File('{fpath}', 'r') as f:
+    dataset = f['{uri}']'''
 
+groupTemplate = '''with h5py.File('{fpath}', 'r') as f:
+    group = f['{uri}']'''
+
+ixTemplate = '''[{ixstr}]'''
 
 ## manager
 class HdfSnippetManager(HdfBaseManager):
     """Implements HDF5 contents handling
     """
-    def _get(self, fpath, uri, ixstr, **kwargs):
-        return dsetTemp.format(fpath=fpath, uri=uri)
+    def _get(self, fpath, uri, ixstr=None, subixstr=None, **kwargs):
+        with h5py.File(fpath, 'r') as f:
+            tipe = hobjType(f[uri])
 
+        if tipe == 'dataset':
+            return ''.join((
+                dsetTemplate.format(fpath=fpath, uri=uri),
+                ixTemplate.format(ixstr=ixstr) if ixstr is not None else '',
+                ixTemplate.format(ixstr=subixstr) if ixstr is not None and subixstr is not None else '',
+            ))
+        elif tipe == 'group':
+            return groupTemplate.format(fpath=fpath, uri=uri)
+        else:
+            raise ValueError('the `hdf/snippet` endpoint currently only supports Dataset and Group objects')
 
 ## handler
 class HdfSnippetHandler(HdfBaseHandler):

--- a/jupyterlab_hdf/util.py
+++ b/jupyterlab_hdf/util.py
@@ -70,7 +70,8 @@ def hobjAttrsDict(hobj):
 
 def hobjContentsDict(hobj, content=False, ixstr=None, min_ndim=None):
     return dict((
-        ('content', hobjMetaDict(hobj, ixstr=ixstr, min_ndim=min_ndim) if content else None),
+        # ensure that 'content' is undefined if not explicitly requested
+        *((('content', hobjMetaDict(hobj, ixstr=ixstr, min_ndim=min_ndim)),) if content else ()),
         *_hobjDict(hobj).items(),
         ('uri', hobj.name),
     ))

--- a/jupyterlab_hdf/util.py
+++ b/jupyterlab_hdf/util.py
@@ -65,10 +65,7 @@ def dsetChunk(dset, ixstr=None, subixstr=None, min_ndim=None):
 ## create dicts to be returned by the various api
 def hobjAttrsDict(hobj):
     return dict((
-        ('attrs', dict((
-            *hobj.attrs.items(),
-        ))),
-        *_hobjDict(hobj).items(),
+        *hobj.attrs.items(),
     ))
 
 def hobjContentsDict(hobj, content=False, ixstr=None, min_ndim=None):

--- a/jupyterlab_hdf/util.py
+++ b/jupyterlab_hdf/util.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from .exception import JhdfError
 
-__all__ = ['atleast_nd', 'dsetChunk', 'hobjAttrsDict', 'hobjContentsDict', 'hobjMetaDict', 'jsonize', 'parseIndex', 'parseSubindex', 'slicelen', 'shapemeta', 'uriJoin', 'uriName']
+__all__ = ['atleast_nd', 'dsetChunk', 'hobjAttrsDict', 'hobjContentsDict', 'hobjMetaDict', 'hobjType', 'jsonize', 'parseIndex', 'parseSubindex', 'slicelen', 'shapemeta', 'uriJoin', 'uriName']
 
 ## array handling
 def atleast_nd(ary, ndim, pos=0):
@@ -87,6 +87,14 @@ def hobjMetaDict(hobj, ixstr=None, min_ndim=None):
     else:
         return d
 
+def hobjType(hobj):
+    if isinstance(hobj, h5py.Dataset):
+        return 'dataset'
+    elif isinstance(hobj, h5py.Group):
+        return 'group'
+    else:
+        return 'other'
+
 def _dsetMetaDict(dset, ixstr=None, min_ndim=None):
     shapekeys = ('labels', 'ndim', 'shape', 'size')
     smeta = {k:v for k,v in shapemeta(dset.shape, ixstr=ixstr, min_ndim=min_ndim).items() if k in shapekeys}
@@ -97,15 +105,9 @@ def _dsetMetaDict(dset, ixstr=None, min_ndim=None):
     ))
 
 def _hobjDict(hobj):
-    if isinstance(hobj, h5py.Dataset):
-        tipe = 'dataset'
-    else:
-        # for now, treat links and such as groups
-        tipe = 'group'
-
     return dict((
         ('name', uriName(hobj.name)),
-        ('type', tipe),
+        ('type', hobjType(hobj)),
     ))
 
 ## index parsing and handling


### PR DESCRIPTION
In current master, the API docs and the actual API are mismatched in a bunch of tiny ways. This PR should hopefully fix most of those.

Also fixes #52