### PR TITLE
ensure that datagrid shape is zeroed out on any hdf/data or hdf/meta fetch error

### DIFF
--- a/src/hdf.ts
+++ b/src/hdf.ts
@@ -303,6 +303,18 @@ export interface IGroupMeta extends IMeta {
   type: "group";
 }
 
+export function datasetMetaEmpty(): IDatasetMeta {
+  return {
+    dtype: "int64",
+    labels: [],
+    name: "",
+    ndim: 0,
+    shape: [],
+    size: 0,
+    type: "dataset"
+  };
+}
+
 // /**
 //  * Typings representing a directory from the Hdf
 //  */


### PR DESCRIPTION
Otherwise we easily end up with datagrid cells in an error state, which can cause infinite further errors as the empty cells continuously retry to fetch bad data.

This fix should also take care of all of the seemingly non-closable error dialogs mentioned in #48