### PR TITLE
Added endpoint tests

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,42 @@
+name: pytest of jupyterlab_hdf
+
+on: [push, pull_request]
+
+jobs:
+  pytest:
+    name: pytest jupyterlab_hdf
+    strategy:
+      matrix:
+        python: [3.6, 3.7, 3.8, 3.9]
+        exclude:
+          - python: 3.6
+          - python: 3.7
+          - python: 3.8
+          - python: 3.9
+      fail-fast: false
+    timeout-minutes: 120
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Cache pip on Linux
+        uses: actions/cache@v2
+        if: startsWith(runner.os, 'Linux')
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python }}-${{ hashFiles('**/requirements.txt', 'setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[test]
+
+      - name: Test with pytest
+        run: |
+          pytest jupyterlab_hdf

--- a/jupyterlab_hdf/tests/test_attrs.py
+++ b/jupyterlab_hdf/tests/test_attrs.py
@@ -1,0 +1,43 @@
+import h5py
+import os
+from jupyterlab_hdf.tests.utils import ServerTest
+
+
+class TestAttrs(ServerTest):
+    def setUp(self):
+        super().setUp()
+
+        with h5py.File(os.path.join(self.notebook_dir, 'test_file.h5'), 'w') as h5file:
+            # Group with no attributes
+            h5file.create_group('group_without_attrs')
+
+            # Group with simple attributes
+            attr_grp = h5file.create_group('group_with_attrs')
+            attr_grp.attrs['string_attr'] = 'I am a group'
+            attr_grp.attrs['number_attr'] = 5676
+
+            # Dataset with non-simple attributes
+            attr_dset = h5file.create_dataset('dataset_with_attrs', shape=())
+            attr_dset.attrs['bool_attr'] = False
+            attr_dset.attrs['list_attr'] = [0, 1, 2]
+
+    def test_group_without_attrs(self):
+        response = self.tester.get(['attrs', 'test_file.h5'], params={'uri': '/group_without_attrs'})
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload == {}
+
+    def test_group_with_simple_attrs(self):
+        response = self.tester.get(['attrs', 'test_file.h5'], params={'uri': '/group_with_attrs'})
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload == {'string_attr': 'I am a group', 'number_attr': 5676}
+
+    def test_dset_with_non_simple_attrs(self):
+        response = self.tester.get(['attrs', 'test_file.h5'], params={'uri': '/dataset_with_attrs'})
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload == {'bool_attr': False, 'list_attr': [0, 1, 2]}

--- a/jupyterlab_hdf/tests/test_contents.py
+++ b/jupyterlab_hdf/tests/test_contents.py
@@ -32,7 +32,7 @@ class TestContents(ServerTest):
         assert response.status_code == 200
         payload = response.json()
         assert payload == [dict((('name', 'dataset_1'), ('type', 'dataset'), ('uri', '/group_with_children/dataset_1'))),
-         dict((('name', 'group_with_attr'), ('type', 'group'), ('uri', '/group_with_children/nested_group')))]
+         dict((('name', 'nested_group'), ('type', 'group'), ('uri', '/group_with_children/nested_group')))]
 
     def test_full_dataset(self):
         uri = '/group_with_children/dataset_1'

--- a/jupyterlab_hdf/tests/test_contents.py
+++ b/jupyterlab_hdf/tests/test_contents.py
@@ -1,0 +1,46 @@
+import h5py
+import os
+import numpy as np
+from jupyterlab_hdf.tests.utils import ServerTest
+
+
+class TestContents(ServerTest):
+    def setUp(self):
+        super().setUp()
+
+        with h5py.File(os.path.join(self.notebook_dir, 'test_file.h5'), 'w') as h5file:
+            # Empty group
+            h5file.create_group('empty_group')
+
+            # Group with 2 children
+            grp = h5file.create_group('group_with_children')
+            # A simple dataset
+            grp['dataset_1'] = np.random.random((2, 3, 4))
+            # and a group
+            grp.create_group('nested_group')
+
+    def test_empty_group(self):
+        response = self.tester.get(['contents', 'test_file.h5'], params={'uri': '/empty_group'})
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload == []
+
+    def test_group_with_children(self):
+        response = self.tester.get(['contents', 'test_file.h5'], params={'uri': '/group_with_children'})
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload == [dict((('name', 'dataset_1'), ('type', 'dataset'), ('uri', '/group_with_children/dataset_1'))),
+         dict((('name', 'group_with_attr'), ('type', 'group'), ('uri', '/group_with_children/nested_group')))]
+
+    def test_full_dataset(self):
+        uri = '/group_with_children/dataset_1'
+        response = self.tester.get(['contents', 'test_file.h5'], params={'uri': uri})
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload['name'] == 'dataset_1'
+        assert payload['type'] == 'dataset'
+        assert payload['uri'] == uri
+        assert isinstance(payload['content'], dict)

--- a/jupyterlab_hdf/tests/test_data.py
+++ b/jupyterlab_hdf/tests/test_data.py
@@ -1,0 +1,48 @@
+import h5py
+import os
+import numpy as np
+from jupyterlab_hdf.tests.utils import ServerTest
+
+ONE_D = np.arange(0, 11, dtype=np.int64)
+TWO_D = np.arange(0, 10, dtype=np.float64).reshape(2, 5) / 10.
+THREE_D = np.arange(0, 24, dtype=np.int64).reshape(2, 3, 4)
+
+
+class TestData(ServerTest):
+    def setUp(self):
+        super().setUp()
+
+        with h5py.File(os.path.join(self.notebook_dir, 'test_file.h5'), 'w') as h5file:
+            h5file['oneD_dataset'] = ONE_D
+            h5file['twoD_dataset'] = TWO_D
+            h5file['threeD_dataset'] = THREE_D
+
+    def test_oneD_dataset(self):
+        response = self.tester.get(['data', 'test_file.h5'], params={'uri': '/oneD_dataset'})
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload == ONE_D.tolist()
+
+    def test_twoD_dataset(self):
+        response = self.tester.get(['data', 'test_file.h5'], params={'uri': '/twoD_dataset'})
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload == TWO_D.tolist()
+
+    def test_threeD_dataset(self):
+        response = self.tester.get(['data', 'test_file.h5'], params={'uri': '/threeD_dataset'})
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload == THREE_D.tolist()
+
+    def test_sliced_threeD_dataset(self):
+        ixstr = ':,1:3, 2'
+        sliced_dataset = THREE_D[:, 1:3, 2]
+        response = self.tester.get(['data', 'test_file.h5'], params={'uri': '/threeD_dataset', 'ixstr': ixstr})
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload == sliced_dataset.tolist()

--- a/jupyterlab_hdf/tests/test_meta.py
+++ b/jupyterlab_hdf/tests/test_meta.py
@@ -1,0 +1,82 @@
+import h5py
+import os
+import numpy as np
+from jupyterlab_hdf.tests.utils import ServerTest
+
+
+class TestMeta(ServerTest):
+    def setUp(self):
+        super().setUp()
+
+        with h5py.File(os.path.join(self.notebook_dir, 'test_file.h5'), 'w') as h5file:
+            # Empty group
+            h5file.create_group('empty_group')
+
+            # Group with 2 children
+            grp = h5file.create_group('group_with_children')
+            # A simple dataset
+            grp['dataset_1'] = np.random.random((2, 3, 4))
+            # and a group with attributes
+            attr_grp = grp.create_group('group_with_attrs')
+            attr_grp.attrs['string_attr'] = 'I am a group'
+            attr_grp.attrs['number_attr'] = 5676
+
+    def test_empty_group(self):
+        response = self.tester.get(['meta', 'test_file.h5'], params={'uri': '/empty_group'})
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload['name'] == 'empty_group'
+        assert payload['type'] == 'group'
+        assert type(payload['id']) == int and payload['id'] > 0
+        assert payload['attributeCount'] == 0
+        assert payload['childrenCount'] == 0
+
+    def test_group_with_children(self):
+        response = self.tester.get(['meta', 'test_file.h5'], params={'uri': '/group_with_children'})
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload['name'] == 'group_with_children'
+        assert payload['type'] == 'group'
+        assert type(payload['id']) == int and payload['id'] > 0
+        assert payload['attributeCount'] == 0
+        assert payload['childrenCount'] == 2
+
+    def test_group_with_attr(self):
+        response = self.tester.get(['meta', 'test_file.h5'], params={'uri': '/group_with_children/group_with_attrs'})
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload['name'] == 'group_with_attrs'
+        assert payload['type'] == 'group'
+        assert type(payload['id']) == int and payload['id'] > 0
+        assert payload['attributeCount'] == 2
+        assert payload['childrenCount'] == 0
+
+    def test_full_dataset(self):
+        response = self.tester.get(['meta', 'test_file.h5'], params={'uri': '/group_with_children/dataset_1'})
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload['name'] == 'dataset_1'
+        assert payload['type'] == 'dataset'
+        assert type(payload['id']) == int and payload['id'] > 0
+        assert payload['attributeCount'] == 0
+        assert 'childrenCount' not in payload
+        assert payload['labels'] == [{'start': 0, 'stop': 2, 'step': 1}, {'start': 0, 'stop': 3, 'step': 1}, {'start': 0, 'stop': 4, 'step': 1}]
+        assert payload['dtype'] == '<f8'
+        assert payload['ndim'] == 3
+        assert payload['shape'] == [2, 3, 4]
+        assert payload['size'] == 24
+
+    def test_sliced_dataset(self):
+        response = self.tester.get(['meta', 'test_file.h5'], params={'uri': '/group_with_children/dataset_1', 'ixstr': ":, 1:3, 2"})
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload['labels'] == [{'start': 0, 'stop': 2, 'step': 1}, {'start': 1, 'stop': 3, 'step': 1}]
+        assert payload['dtype'] == '<f8'
+        assert payload['ndim'] == 2
+        assert payload['shape'] == [2, 2]
+        assert payload['size'] == 4

--- a/jupyterlab_hdf/tests/utils.py
+++ b/jupyterlab_hdf/tests/utils.py
@@ -1,0 +1,48 @@
+"""Helpers for tests"""
+
+import json
+from typing import List
+from traitlets.config import Config
+
+from notebook.tests.launchnotebook import NotebookTestBase as ServerTestBase
+from notebook.utils import url_path_join
+
+NS = "/hdf"
+
+
+class APITester(object):
+    """Wrapper for REST API requests"""
+
+    url = "/hdf"
+
+    def __init__(self, request):
+        self.request = request
+
+    def _req(self, verb: str, path: List[str], body=None, params=None):
+        if body is not None:
+            body = json.dumps(body)
+        response = self.request(
+            verb, url_path_join(self.url, *path), data=body, params=params
+        )
+
+        if 400 <= response.status_code < 600:
+            try:
+                response.reason = response.json()["message"]
+            except Exception:
+                pass
+        response.raise_for_status()
+
+        return response
+
+    def get(self, path: List[str], body=None, params=None):
+        return self._req("GET", path, body, params)
+
+
+class ServerTest(ServerTestBase):
+
+    # Force extension enabling - Disabled by parent class otherwise
+    config = Config({"NotebookApp": {"nbserver_extensions": {"jupyterlab_hdf": True}}})
+
+    def setUp(self):
+        super(ServerTest, self).setUp()
+        self.tester = APITester(self.request)

--- a/jupyterlab_hdf/util.py
+++ b/jupyterlab_hdf/util.py
@@ -283,6 +283,8 @@ def jsonize(v):
             ('stop', v.stop),
             ('step', v.step),
         ))
+    if isinstance(v, np.bool_):
+        return bool(v)
     return v
 
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,10 @@ setup_dict = dict(
         'h5py',
         'notebook',
         'simplejson'
-    ]
+    ],
+    extras_require={
+        'test': ['numpy', 'pytest']
+    }
 )
 
 try:


### PR DESCRIPTION
I reused the `testutils` from [jupyterlab-git](https://github.com/jupyterlab/jupyterlab-git/blob/master/jupyterlab_git/tests/testutils.py). 
This makes the notebook running in a temporary directory so I found easier to create HDF5 files on the fly rather than to use the ones from `example`.

Tests are not very involved for now but I hope it will be a good building base.

Tests are run by `pytest`.