### PR TITLE
fixup `python.yml` workflow schema

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,4 +1,4 @@
-name: pytest of jupyterlab_hdf
+name: pytest
 
 on: [push, pull_request]
 
@@ -8,11 +8,6 @@ jobs:
     strategy:
       matrix:
         python: [3.6, 3.7, 3.8, 3.9]
-        exclude:
-          - python: 3.6
-          - python: 3.7
-          - python: 3.8
-          - python: 3.9
       fail-fast: false
     timeout-minutes: 120
     runs-on: ubuntu-latest
@@ -35,8 +30,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[test]
+          python -m pip install -e .[test]
 
       - name: Test with pytest
         run: |
-          pytest jupyterlab_hdf
+          python -m pytest jupyterlab_hdf

--- a/setup.py
+++ b/setup.py
@@ -42,10 +42,14 @@ setup_dict = dict(
     install_requires=[
         'h5py',
         'notebook',
-        'simplejson'
+        'simplejson',
     ],
     extras_require={
-        'test': ['numpy', 'pytest']
+        'test': [
+            'numpy',
+            'pytest',
+            'requests',
+        ]
     }
 )
 


### PR DESCRIPTION
fixup the `python.yml` github actions workflow schema added in #66. Once this is done, all of the tests added in #66 will run as CI on all pushes and pull requests