### PR TITLE
Made jsonize method more robust for numpy array scalars

### DIFF
--- a/jupyterlab_hdf/tests/test_attrs.py
+++ b/jupyterlab_hdf/tests/test_attrs.py
@@ -1,4 +1,5 @@
 import h5py
+import numpy as np
 import os
 from jupyterlab_hdf.tests.utils import ServerTest
 
@@ -15,6 +16,7 @@ class TestAttrs(ServerTest):
             attr_grp = h5file.create_group('group_with_attrs')
             attr_grp.attrs['string_attr'] = 'I am a group'
             attr_grp.attrs['number_attr'] = 5676
+            attr_grp.attrs['float64_attr'] = np.float64(3.1417)
 
             # Dataset with non-simple attributes
             attr_dset = h5file.create_dataset('dataset_with_attrs', shape=())
@@ -34,7 +36,7 @@ class TestAttrs(ServerTest):
 
         assert response.status_code == 200
         payload = response.json()
-        assert payload == {'string_attr': 'I am a group', 'number_attr': 5676}
+        assert payload == {'string_attr': 'I am a group', 'number_attr': 5676, 'float64_attr': 3.1417}
 
     def test_dset_with_non_simple_attrs(self):
         response = self.tester.get(['attrs', 'test_file.h5'], params={'uri': '/dataset_with_attrs'})

--- a/jupyterlab_hdf/tests/test_data.py
+++ b/jupyterlab_hdf/tests/test_data.py
@@ -4,7 +4,7 @@ import numpy as np
 from jupyterlab_hdf.tests.utils import ServerTest
 
 
-SCALAR = 56
+SCALAR = np.int32(56)
 ONE_D = np.arange(0, 11, dtype=np.int64)
 TWO_D = np.arange(0, 10, dtype=np.float64).reshape(2, 5) / 10.
 THREE_D = np.arange(0, 24, dtype=np.int64).reshape(2, 3, 4)

--- a/jupyterlab_hdf/util.py
+++ b/jupyterlab_hdf/util.py
@@ -281,9 +281,7 @@ def jsonize(v):
         return {k:jsonize(v) for k,v in v.items()}
     if isinstance(v, (list, tuple)):
         return [jsonize(i) for i in v]
-    if isinstance(v, np.integer):
-        return int(v)
-    if isinstance(v, np.ndarray):
+    if isinstance(v, np.generic) or isinstance(v, np.ndarray):
         return jsonize(v.tolist())
     if isinstance(v, slice):
         return dict((
@@ -291,8 +289,6 @@ def jsonize(v):
             ('stop', v.stop),
             ('step', v.step),
         ))
-    if isinstance(v, np.bool_):
-        return bool(v)
     if isinstance(v, complex):
         return str(v)
     if isinstance(v, h5py.Empty):


### PR DESCRIPTION
Investigating https://github.com/jupyterlab/jupyterlab-hdf5/issues/40#issuecomment-785876603, I realized the `jsonize` of numpy array scalars could be more robust/generic.

I made use of [np.generic](https://numpy.org/doc/stable/reference/arrays.scalars.html) so that all `np.int...`, `np.float..` and even `np.bool` are covered.