### PR TITLE
downgrade to `typescript@^3.9.0` for jlab 2.x compatibility

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,7 +1,7 @@
 channels:
 - conda-forge
 dependencies:
-- jupyterlab=2.2
-- nodejs=14
+- jupyterlab<3
+- nodejs=15.8
 # Python Kernel
 - python=3.7

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,5 +1,16 @@
 #!/bin/bash
+mkdir -p /tmp/yarn
+export YARN_CACHE_FOLDER="/tmp/yarn"
 
-set -ex
+python --version
 
-jlpm build:dev
+jupyter lab clean --all
+
+pip install -e .[dev]
+
+jupyter --version
+
+jlpm
+jlpm build
+jupyter labextension install . --no-build
+jupyter lab build --debug

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,6 +1,0 @@
-h5py
-simplejson
-black
-numpy
-pytest
-requests

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "prettier": "^2.2.1",
     "rimraf": "~2.6.2",
     "shell-quote": "^1.7.2",
-    "typescript": "^4.1.3",
+    "typescript": "^3.9.0",
     "yarn-deduplicate": "^3.1.0"
   },
   "publishConfig": {

--- a/setup.py
+++ b/setup.py
@@ -39,9 +39,10 @@ setup_dict = dict(
     ],
     install_requires=[
         "h5py",
-        "jupyterlab<=3",
+        "notebook",
         "numpy",
         "simplejson",
+        "tornado",
     ],
     extras_require={
         "dev": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2532,10 +2532,10 @@ typed-styles@^0.0.7:
   resolved "https://registry.yarnpkg.com/typed-styles/-/typed-styles-0.0.7.tgz#93392a008794c4595119ff62dde6809dbc40a3d9"
   integrity sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q==
 
-typescript@^4.1.3:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.2.tgz#1450f020618f872db0ea17317d16d8da8ddb8c4c"
-  integrity sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==
+typescript@^3.9.0:
+  version "3.9.9"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.9.tgz#e69905c54bc0681d0518bd4d587cc6f2d0b1a674"
+  integrity sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==
 
 typestyle@^2.0.4:
   version "2.1.0"


### PR DESCRIPTION
fixes #85