### PR TITLE
Added possibility to view current path attributes

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -6,7 +6,7 @@ python --version
 
 jupyter lab clean --all
 
-pip install -e .[dev]
+pip install .[dev]
 
 jupyter --version
 

--- a/src/hdf.ts
+++ b/src/hdf.ts
@@ -61,6 +61,15 @@ export function parseHdfQuery(path: string): IContentsParameters {
   };
 }
 
+export function nameFromPath(path: string): string {
+  if (path === '' || path === '/') {
+    return '/';
+  }
+
+  const parts = path.split('/');
+  return parts[parts.length - 1];
+}
+
 /**
  * make a parameterized request to the `hdf/attrs` api
  */


### PR DESCRIPTION
The attribute viewer implemented in #80 allows to view the attributes of a selected entity in the HDF5 browser. 

As the root group cannot be selected in this browser, the attributes cannot be viewed.

This PR aims to solve this by adding a context menu entry to view the attributes of the current explored group when no entity is selected.

![image](https://user-images.githubusercontent.com/42204205/110943331-64a86a00-833b-11eb-8dbc-a312d9a1d478.png)
