### PR TITLE
Jsonize NaN and Infinity as strings

### DIFF
--- a/jupyterlab_hdf/tests/test_data.py
+++ b/jupyterlab_hdf/tests/test_data.py
@@ -22,6 +22,7 @@ class TestData(ServerTest):
             h5file["complex"] = COMPLEX
             h5file["scalar"] = SCALAR
             h5file["empty"] = h5py.Empty(">f8")
+            h5file["NaNs"] = [np.NaN, np.inf, np.NINF, 0]
 
     def test_oneD_dataset(self):
         response = self.tester.get(["data", "test_file.h5"], params={"uri": "/oneD_dataset"})
@@ -88,3 +89,10 @@ class TestData(ServerTest):
         assert response.status_code == 200
         payload = response.json()
         assert payload is None
+
+    def test_dataset_with_NaNs(self):
+        response = self.tester.get(["data", "test_file.h5"], params={"uri": "/NaNs"})
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload == ["NaN", "Infinity", "-Infinity", 0]

--- a/jupyterlab_hdf/util.py
+++ b/jupyterlab_hdf/util.py
@@ -329,6 +329,12 @@ def jsonize(v):
         return [v.real, v.imag]
     if isinstance(v, h5py.Empty):
         return None
+    if isinstance(v, float) and np.isnan(v):
+        return "NaN"
+    if isinstance(v, float) and np.isposinf(v):
+        return "Infinity"
+    if isinstance(v, float) and np.isneginf(v):
+        return "-Infinity"
     return v
 
 


### PR DESCRIPTION
### Current approach
The treatment of `NaN` and `(-)Infinity` implemented in https://github.com/jupyterlab/jupyterlab-hdf5/pull/41/commits/f427b2ece59c1382054853d3c9ab0a941b1b0f70 serialize them as `null` to get valid JSON.

This raises the following problems:
- `NaN` and `(-)Infinity` cannot be distinguished from each other once serialized
- There is conflict with the value of a dataset `h5py.Empty` which is also  `null` https://github.com/jupyterlab/jupyterlab-hdf5/pull/79

### What this PR does
It implements the approach described by @kgryte in https://github.com/jupyterlab/jupyterlab-hdf5/issues/22: `NaN` and `(-)Infinity` are serialized as strings. This allows a front-end consumer to distinguish between the two and use a reviver to parse it to the desired value (e.g. `Number.NaN` or `Number.POSITIVE_INFINITY` in JS).