### PR TITLE
Serialize JSON with orjson rather than simplejson

### DIFF
--- a/jupyterlab_hdf/attrs.py
+++ b/jupyterlab_hdf/attrs.py
@@ -4,7 +4,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 from .baseHandler import HdfFileManager, HdfBaseHandler
-from .util import hobjAttrsDict, jsonize
+from .util import hobjAttrsDict
 
 __all__ = ["HdfAttrsManager", "HdfAttrsHandler"]
 
@@ -13,7 +13,7 @@ class HdfAttrsManager(HdfFileManager):
     """Implements HDF5 attributes handling"""
 
     def _getFromFile(self, f, uri, attr_keys=None, **kwargs):
-        return jsonize(hobjAttrsDict(f[uri], attr_keys))
+        return hobjAttrsDict(f[uri], attr_keys)
 
 
 ## handler

--- a/jupyterlab_hdf/baseHandler.py
+++ b/jupyterlab_hdf/baseHandler.py
@@ -5,7 +5,7 @@
 
 import h5py
 import os
-import simplejson
+import orjson
 import traceback
 from tornado import web
 from tornado.httpclient import HTTPError
@@ -15,6 +15,7 @@ from notebook.utils import url_path_join
 
 # from .config import HdfConfig
 from .exception import JhdfError
+from .util import jsonize
 
 __all__ = ["HdfBaseManager", "HdfFileManager", "HdfBaseHandler"]
 
@@ -133,7 +134,7 @@ class HdfBaseHandler(APIHandler):
             kwargs[k] = int(kwargs[k])
 
         try:
-            self.finish(simplejson.dumps(self.manager.get(path, uri, **kwargs), ignore_nan=True))
+            self.finish(orjson.dumps(self.manager.get(path, uri, **kwargs), default=jsonize, option=orjson.OPT_SERIALIZE_NUMPY))
         except HTTPError as err:
             self.set_status(err.code)
             response = err.response.body if err.response else str(err.code)

--- a/jupyterlab_hdf/contents.py
+++ b/jupyterlab_hdf/contents.py
@@ -6,38 +6,39 @@
 import h5py
 
 from .baseHandler import HdfFileManager, HdfBaseHandler
-from .util import hobjContentsDict, jsonize, uriJoin, uriName
+from .util import hobjContentsDict
 
-__all__ = ['HdfContentsManager', 'HdfContentsHandler']
+__all__ = ["HdfContentsManager", "HdfContentsHandler"]
 
 ## manager
 class HdfContentsManager(HdfFileManager):
-    """Implements HDF5 contents handling
-    """
+    """Implements HDF5 contents handling"""
+
     def _getFromFile(self, f, uri, ixstr=None, min_ndim=None, **kwargs):
         hobj = f[uri]
 
         if isinstance(hobj, h5py.Group):
             # recurse one level
             return [
-                jsonize(hobjContentsDict(
+                hobjContentsDict(
                     subhobj,
                     content=False,
                     ixstr=ixstr,
                     min_ndim=min_ndim,
-                ))
+                )
                 for subhobj in hobj.values()
             ]
         else:
-            return jsonize(hobjContentsDict(
+            return hobjContentsDict(
                 hobj,
                 content=True,
                 ixstr=ixstr,
                 min_ndim=min_ndim,
-            ))
+            )
+
 
 ## handler
 class HdfContentsHandler(HdfBaseHandler):
-    """A handler for HDF5 contents
-    """
+    """A handler for HDF5 contents"""
+
     managerClass = HdfContentsManager

--- a/jupyterlab_hdf/data.py
+++ b/jupyterlab_hdf/data.py
@@ -8,14 +8,14 @@ try:
 except ImportError:
     pass
 from .baseHandler import HdfFileManager, HdfBaseHandler
-from .util import dsetChunk, jsonize
+from .util import dsetChunk
 
-__all__ = ['HdfDataManager', 'HdfDataHandler']
+__all__ = ["HdfDataManager", "HdfDataHandler"]
 
 ## manager
 class HdfDataManager(HdfFileManager):
-    """Implements HDF5 data handling
-    """
+    """Implements HDF5 data handling"""
+
     def _getFromFile(self, f, uri, ixstr=None, subixstr=None, min_ndim=None, **kwargs):
         # # DEBUG: uncomment for logging
         # from .util import dsetContentDict, parseSubindex
@@ -25,10 +25,11 @@ class HdfDataManager(HdfFileManager):
         #     logd['ixcompound'] = parseSubindex(ixstr, subixstr, f[uri].shape)
         # self.log.info('{}'.format(logd))
 
-        return jsonize(dsetChunk(f[uri], ixstr=ixstr, subixstr=subixstr, min_ndim=min_ndim))
+        return dsetChunk(f[uri], ixstr=ixstr, subixstr=subixstr, min_ndim=min_ndim)
+
 
 ## handler
 class HdfDataHandler(HdfBaseHandler):
-    """A handler for HDF5 data
-    """
+    """A handler for HDF5 data"""
+
     managerClass = HdfDataManager

--- a/jupyterlab_hdf/meta.py
+++ b/jupyterlab_hdf/meta.py
@@ -4,19 +4,20 @@
 # Distributed under the terms of the Modified BSD License.
 
 from .baseHandler import HdfFileManager, HdfBaseHandler
-from .util import hobjMetaDict, jsonize
+from .util import hobjMetaDict
 
-__all__ = ['HdfMetaManager', 'HdfMetaHandler']
+__all__ = ["HdfMetaManager", "HdfMetaHandler"]
 
 ## manager
 class HdfMetaManager(HdfFileManager):
-    """Implements HDF5 metadata handling
-    """
+    """Implements HDF5 metadata handling"""
+
     def _getFromFile(self, f, uri, ixstr=None, min_ndim=None, **kwargs):
-        return jsonize(hobjMetaDict(f[uri], ixstr=ixstr, min_ndim=min_ndim))
+        return hobjMetaDict(f[uri], ixstr=ixstr, min_ndim=min_ndim)
+
 
 ## handler
 class HdfMetaHandler(HdfBaseHandler):
-    """A handler for HDF5 metadata
-    """
+    """A handler for HDF5 metadata"""
+
     managerClass = HdfMetaManager

--- a/jupyterlab_hdf/util.py
+++ b/jupyterlab_hdf/util.py
@@ -309,6 +309,8 @@ def validateSubindex(shape, size, ixstr, subixstr):
 ## json handling
 def jsonize(v):
     """Turns a value into a JSON serializable version"""
+    if isinstance(v, (int, float, str)):
+        return v
     if isinstance(v, bytes):
         return v.decode()
     if isinstance(v, dict):
@@ -329,7 +331,7 @@ def jsonize(v):
         return [v.real, v.imag]
     if isinstance(v, h5py.Empty):
         return None
-    return v
+    raise TypeError("Cannot jsonize {}".format(type(v)))
 
 
 ## uri handling

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup_dict = dict(
         "h5py",
         "notebook",
         "numpy",
-        "simplejson",
+        "orjson",
         "tornado",
     ],
     extras_require={


### PR DESCRIPTION
I have made some tries lately with big data arrays and saw that the JSON serialization was taking a long time **and** blocking the server.

As a first easy fix, I would propose to replace simplejson with [orjson](https://github.com/ijl/orjson), [a much faster](https://github.com/ijl/orjson#performance) JSON serializer that natively [serializes numpy.ndarray of supported dtypes](https://github.com/ijl/orjson#numpy). 

The use of the `jsonize` function as `default` ensures that unsupported dtypes (such as complex) are still serialized as before. This means complex data arrays will have to be serialized using the 'old' and slower method. However, the performance gain for supported numpy arrays is quite worthwhile: orjson goes approximately ten times faster than the current implementation using simplejson (see a simple comparison script at https://gist.github.com/loichuder/82f75e336b742d63ba2817ab271ddca6).

From what I see, simplejson was added in https://github.com/jupyterlab/jupyterlab-hdf5/pull/41 to parse NaN and Infinity as `null`. This is done naitvely in orjson. Note: #97 will have to be revised. 